### PR TITLE
Updated license in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "Programming Language :: Python :: 3.3",
     ],
     keywords='audio music sound',
-    license='GPL',
+    license='ISC',
     install_requires=[
         'audioread',
         'numpy >= 1.8.0',


### PR DESCRIPTION
LICENSE.md states that the license for this project is now the ISC license, and commit messages also state that the project switched from GPL to ISC. This PR updates setup.py, so PyPI will (hopefully) show the correct license from now on.