### PR TITLE
CQT Enhancements

### DIFF
--- a/librosa/core.py
+++ b/librosa/core.py
@@ -690,16 +690,20 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     fmin_top = freqs[-bins_per_octave-1]
 
     # Generate the basis filters
-    basis = np.asarray(filters.constant_q(sr,
-                                          fmin=fmin_top,
-                                          n_bins=bins_per_octave,
-                                          bins_per_octave=bins_per_octave,
-                                          tuning=tuning,
-                                          resolution=resolution,
-                                          pad=True))
+    basis, lengths = filters.constant_q(sr,
+                                        fmin=fmin_top,
+                                        n_bins=bins_per_octave,
+                                        bins_per_octave=bins_per_octave,
+                                        tuning=tuning,
+                                        resolution=resolution,
+                                        pad=True,
+                                        return_lengths=True)
+
+    basis = np.asarray(basis)
 
     # FFT the filters
     max_filter_length = basis.shape[1]
+    min_filter_length = min(lengths)
     n_fft = int(2.0**(np.ceil(np.log2(max_filter_length))))
 
     # Conjugate-transpose the basis
@@ -717,14 +721,14 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         to the desired resolution.
         '''
 
-        # If target_hop <= n_fft / 2:
+        # If target_hop <= min_filter_length / 2:
         #   my_hop = target_hop
         # else:
         #   my_hop = target_hop * 2**(-k)
 
         zoom_factor = int(np.maximum(0,
                                      1 + np.ceil(np.log2(target_hop)
-                                                 - np.log2(n_fft))))
+                                                 - np.log2(min_filter_length))))
 
         my_hop = int(target_hop / (2**(zoom_factor)))
 

--- a/librosa/core.py
+++ b/librosa/core.py
@@ -614,7 +614,7 @@ def magphase(D):
 
 @cache
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
-        bins_per_octave=12, tuning=None, resolution=2, res_type='sinc_best',
+        bins_per_octave=12, tuning=None, resolution=2, res_type='sinc_fastest',
         aggregate=None):
     '''Compute the constant-Q transform of an audio signal.
 
@@ -778,6 +778,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     # Transpose magic here to ensure column-contiguity
     return np.ascontiguousarray(cqt_resp.T).T
+
 
 @cache
 def sparsify_fft_basis(fft_basis, sparse_limit=0.01):

--- a/librosa/core.py
+++ b/librosa/core.py
@@ -615,7 +615,7 @@ def magphase(D):
 @cache
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         bins_per_octave=12, tuning=None, resolution=2, res_type='sinc_fastest',
-        aggregate=None):
+        aggregate=None, norm=2):
     '''Compute the constant-Q transform of an audio signal.
 
     :usage:
@@ -666,6 +666,10 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
           Aggregation function for time-oversampling energy aggregation.
           By default, ``np.mean``.  See :func:`librosa.feature.sync()`.
 
+      - norm : {inf, -inf, 0, float > 0}
+          Type of norm to use for basis function normalization.
+          See librosa.util.normalize
+
     :returns:
       - CQT : np.ndarray [shape=(d, t), dtype=np.float]
           Constant-Q energy for each frequency at each time.
@@ -697,6 +701,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                         tuning=tuning,
                                         resolution=resolution,
                                         pad=True,
+                                        norm=norm,
                                         return_lengths=True)
 
     basis = np.asarray(basis)

--- a/librosa/core.py
+++ b/librosa/core.py
@@ -614,7 +614,7 @@ def magphase(D):
 
 @cache
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
-        bins_per_octave=12, tuning=None, resolution=2, res_type='sinc_fastest',
+        bins_per_octave=12, tuning=None, resolution=2, res_type='sinc_best',
         aggregate=None, norm=2):
     '''Compute the constant-Q transform of an audio signal.
 

--- a/librosa/core.py
+++ b/librosa/core.py
@@ -749,6 +749,9 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
             my_cqt = feature.sync(my_cqt, bounds,
                                   aggregate=aggregate)
 
+        # normalize as in Parseval's relation
+        my_cqt /= n_fft
+
         return my_cqt
 
     cqt_resp = []

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -267,7 +267,7 @@ def logfrequency(sr, n_fft, n_bins=84, bins_per_octave=12, tuning=0.0,
 
 @cache
 def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
-               window=None, resolution=2, pad=False,
+               window=None, resolution=2, pad=False, norm=2,
                return_lengths=False, **kwargs):
     r'''Construct a constant-Q basis.
 
@@ -309,6 +309,10 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
           Pad all filters to have constant width (equal to the longest filter).
           By default, padding is done with zeros, but this can be overridden
           by setting the ``mode=`` field in *kwargs*.
+
+      - norm : {inf, -inf, 0, float > 0}
+          Type of norm to use for basis function normalization.
+          See librosa.util.normalize
 
       - return_lengths : boolean
           Whether to return the pre-padding filter lengths along with the filters.
@@ -359,7 +363,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
             win = win * window(ilen)
 
         # Normalize
-        win = librosa.util.normalize(win, norm=2)
+        win = librosa.util.normalize(win, norm=norm)
 
         filters.append(win)
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -337,8 +337,13 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
 
     filters = []
     for i in np.arange(n_bins, dtype=float):
-        # Length of this filter
-        ilen = np.ceil(Q * sr / (fmin * 2.0**(i / bins_per_octave)))
+
+        freq = fmin * 2.0**(i / bins_per_octave)
+        if (1+1.0/Q)*freq > sr/2:
+            raise ValueError("Filter pass band lies beyond Nyquist")
+
+        # Length of the filter
+        ilen = np.ceil(Q * sr / freq)
 
         # Build the filter
         win = np.exp(Q * 1j * np.linspace(0, 2 * np.pi, ilen, endpoint=False))

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -267,7 +267,8 @@ def logfrequency(sr, n_fft, n_bins=84, bins_per_octave=12, tuning=0.0,
 
 @cache
 def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
-               window=None, resolution=2, pad=False, **kwargs):
+               window=None, resolution=2, pad=False,
+               return_lengths=False, **kwargs):
     r'''Construct a constant-Q basis.
 
     :usage:
@@ -309,6 +310,9 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
           By default, padding is done with zeros, but this can be overridden
           by setting the ``mode=`` field in *kwargs*.
 
+      - return_lengths : boolean
+          Whether to return the pre-padding filter lengths along with the filters.
+
       - *kwargs*
           Additional keyword arguments to ``np.pad()`` when ``pad==True``.
 
@@ -336,6 +340,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
     Q = float(resolution) / (2.0**(1. / bins_per_octave) - 1)
 
     filters = []
+    lengths = []
     for i in np.arange(n_bins, dtype=float):
 
         freq = fmin * 2.0**(i / bins_per_octave)
@@ -344,6 +349,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
 
         # Length of the filter
         ilen = np.ceil(Q * sr / freq)
+        lengths.append(ilen)
 
         # Build the filter
         win = np.exp(Q * 1j * np.linspace(0, 2 * np.pi, ilen, endpoint=False))
@@ -364,7 +370,10 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
         for i in range(len(filters)):
             filters[i] = librosa.util.pad_center(filters[i], max_len, **kwargs)
 
-    return filters
+    if return_lengths:
+        return filters, lengths
+    else:
+        return filters
 
 
 @cache


### PR DESCRIPTION
This adds:

1. An aliasing check when creating CQT filters
2. Changes the CQT oversampling/aggregation hop to be based on the shortest filter rather than the longest filter.
3. Adds 1/N Parseval normalization to CQT output.
4. Adds a `norm` argument to cqt and filters.constant_q in order to allow normalization using a different norm.
5. Does "sparsification" on fft_basis in order to exploit sparse ops.  (Without this there's no reason to do the processing in the frequency domain).

Let me know if any of these are useful.  I'm happy to revert any of them if a subset are useful.  Not sure what kind of lint requirements you have.  Also, I wasn't able to run the tests because I don't have matlab.  Why is Matlab a requirement for a Python library. ;)  