### PR TITLE
Further CQT Enhancements

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -124,10 +124,10 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         tuning = estimate_tuning(y=y, sr=sr)
 
     # First thing, get the fmin of the top octave
-    freqs = time_frequency.cqt_frequencies(n_bins + 1, fmin,
+    freqs = time_frequency.cqt_frequencies(n_bins, fmin,
                                            bins_per_octave=bins_per_octave)
 
-    fmin_top = freqs[-bins_per_octave-1]
+    fmin_top = freqs[-bins_per_octave]
 
     # Generate the basis filters
     basis, lengths = filters.constant_q(sr,

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -187,8 +187,9 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
         assert my_hop > 0
 
-        # Compute the STFT matrix
-        D = stft(my_y, n_fft=n_fft, hop_length=my_hop)
+        # Compute the STFT matrix. No window needed (ones=rectangular)
+        D = stft(my_y, n_fft=n_fft, hop_length=my_hop,
+                 window=np.ones)
 
         D = D.conj() # stft returns conjugate for some reason
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -136,17 +136,19 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                         bins_per_octave=bins_per_octave,
                                         tuning=tuning,
                                         resolution=resolution,
-                                        pad=True,
                                         norm=norm,
                                         return_lengths=True)
 
-    basis = np.asarray(basis)
-
     # FFT the filters
-    max_filter_length = basis.shape[1]
+    max_filter_length = np.max(lengths)
     min_filter_length = np.min(lengths)
 
     n_fft = int(2.0**(np.ceil(np.log2(max_filter_length))))
+
+    # pad and center with respect to window of length n_fft
+    for i in xrange(len(basis)):
+        basis[i] = util.pad_center(basis[i], n_fft)
+    basis = np.asarray(basis)
 
     # Conjugate-transpose the basis
     fft_basis = np.fft.fft(basis, n=n_fft, axis=1).conj()

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -150,9 +150,13 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         basis[i] = util.pad_center(basis[i], n_fft)
     basis = np.asarray(basis)
 
-    # Conjugate-transpose the basis
+    # FFT the filters
     fft_basis = np.fft.fft(basis, n=n_fft, axis=1).conj()
 
+    # Only need positive frequencies
+    fft_basis = fft_basis[:,:(n_fft/2+1)]
+
+    # Sparsify fft_basis
     fft_basis = util.sparsify(fft_basis)
 
     n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))
@@ -186,7 +190,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         # Compute the STFT matrix
         D = stft(my_y, n_fft=n_fft, hop_length=my_hop)
 
-        D = np.vstack([D.conj(), D[-2:0:-1]])
+        D = D.conj() # stft returns conjugate for some reason
 
         # And filter response energy
         my_cqt = np.abs(fft_basis.dot(D))

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -395,7 +395,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
 
     lengths : np.ndarray
         If `return_lengths == True`, then the length of each filter
-        if also returned.
+        is also returned.
 
     See Also
     --------


### PR DESCRIPTION
This add a few things to the CQT:
1. Removes extra CQT frequency generated (I don't think there's a reason for an extra one).
2. Centers the filters with respect to the center of the FFT window.
3. Only operates on the portion of the spectrum corresponding to positive frequencies. (The complex filters are zero at negative frequencies anyway).  This save a bit of compute and memory.
4. Removes the Hann window from the STFT (We don't need an analysis window since we're not doing frequency analysis, we're just projecting onto basis functions).  