### PR TITLE
Fix constant-Q frequency drift when rounding window size

### DIFF
--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -425,7 +425,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
             raise ValueError("Filter pass band lies beyond Nyquist")
 
         # Length of the filter
-        ilen = np.ceil(Q * sr / freq)
+        ilen = Q * sr / freq
         lengths.append(ilen)
 
         # Build the filter

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -364,8 +364,6 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
 
     window : function or `None`
         Windowing function to apply to filters.
-        If `None`, no window is applied.
-
         Default: `scipy.signal.hann`
 
     resolution : float > 0 [scalar]
@@ -431,16 +429,15 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
         lengths.append(ilen)
 
         # Build the filter
-        win = np.exp(Q * 1j * np.linspace(0, 2 * np.pi, ilen, endpoint=False))
+        sig = np.exp(1j*2*np.pi*freq*np.arange(ilen, dtype=float)/sr)
 
         # Apply the windowing function
-        if window is not None:
-            win = win * window(ilen)
+        sig = sig * window(ilen)
 
         # Normalize
-        win = util.normalize(win, norm=norm)
+        sig = util.normalize(sig, norm=norm)
 
-        filters.append(win)
+        filters.append(sig)
 
     max_len = max(lengths)
     if pad_fft:


### PR DESCRIPTION
This fixes constant-Q center frequency drift when rounding the window size up to an integer value.  It seems tolerable to allow the bandwidth of the filters to change with rounding as it's easiest to define the Hann window as an integer length.  However, it's pretty easy to fix the frequency rounding problem by using the floating point frequency when generating the complex exponential before windowing.  

Also, I removed the unnecessary check for window == None and the incorrect None means "no window is applied" line in the documentation.