### PR TITLE
Add automatic res_type detection for CQT

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -12,6 +12,12 @@ import scipy.signal
 from .. import cache
 from .. import util
 
+# Resampling bandwidths as percentage of Nyquist
+# http://www.mega-nerd.com/SRC/api_misc.html#Converters
+BW_BEST = 0.97
+BW_MEDIUM = 0.9
+BW_FASTEST = 0.8
+
 # Do we have scikits.samplerate?
 try:
     # Pylint won't handle dynamic imports, so we suppress this warning

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -15,6 +15,11 @@ from .. import util
 from ..feature.utils import sync
 
 
+BW_BEST = 0.97
+BW_MEDIUM = 0.9
+BW_FASTEST = 0.8
+
+
 @cache
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         bins_per_octave=12, tuning=None, resolution=2,
@@ -147,11 +152,11 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     filter_cutoff = fmax_t*(1 + 0.725 / Q) # 0.725 for Hann window
     nyquist = sr / 2.0
 
-    if filter_cutoff < 0.8*nyquist:
+    if filter_cutoff < BW_FASTEST*nyquist:
         res_type = 'sinc_fastest'
-    elif filter_cutoff < 0.9*nyquist:
+    elif filter_cutoff < BW_MEDIUM*nyquist:
         res_type = 'sinc_medium'
-    elif filter_cutoff < 0.97*nyquist:
+    elif filter_cutoff < BW_BEST*nyquist:
         res_type = 'sinc_best'
     else:
         res_type = 'sinc_best'

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -16,7 +16,7 @@ from ..feature.utils import sync
 
 @cache
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
-        bins_per_octave=12, tuning=None, resolution=2, res_type='sinc_best',
+        bins_per_octave=12, tuning=None, resolution=2,
         aggregate=None, norm=2, sparsity=0.01):
     '''Compute the constant-Q transform of an audio signal.
 
@@ -87,9 +87,6 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     resolution : float > 0
         Filter resolution factor. Larger values use longer windows.
-
-    res_type : str
-        Resampling type, see `librosa.core.resample` for details.
 
     aggregate : None or function
         Aggregation function for time-oversampling energy aggregation.

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -15,9 +15,6 @@ from .. import util
 from ..feature.utils import sync
 
 
-BW_BEST = 0.97
-BW_MEDIUM = 0.9
-BW_FASTEST = 0.8
 
 
 @cache
@@ -152,11 +149,11 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     filter_cutoff = fmax_t*(1 + 0.725 / Q) # 0.725 for Hann window
     nyquist = sr / 2.0
 
-    if filter_cutoff < BW_FASTEST*nyquist:
+    if filter_cutoff < audio.BW_FASTEST*nyquist:
         res_type = 'sinc_fastest'
-    elif filter_cutoff < BW_MEDIUM*nyquist:
+    elif filter_cutoff < audio.BW_MEDIUM*nyquist:
         res_type = 'sinc_medium'
-    elif filter_cutoff < BW_BEST*nyquist:
+    elif filter_cutoff < audio.BW_BEST*nyquist:
         res_type = 'sinc_best'
     else:
         res_type = 'sinc_best'
@@ -173,7 +170,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         # filter_cutoff < BW*nyquist  # (BW is resampling bandwidth fraction)
         # hop_length > 2**n_octaves
 
-        downsample_count1 = int(np.ceil(np.log2(BW_FASTEST * nyquist
+        downsample_count1 = int(np.ceil(np.log2(audio.BW_FASTEST * nyquist
                                                 / filter_cutoff)) - 1)
         downsample_count2 = int(np.ceil(np.log2(hop_length) - n_octaves) - 1)
         downsample_count = min(downsample_count1, downsample_count2)
@@ -225,7 +222,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         n_octaves -= 1
 
         filter_cutoff = fmax_t*(1 + 0.725 / Q) # 0.725 for Hann window
-        assert filter_cutoff < BW_FASTEST*nyquist
+        assert filter_cutoff < audio.BW_FASTEST*nyquist
 
         res_type = 'sinc_fastest'
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -144,8 +144,8 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     # Determine required resampling quality
     Q = float(resolution) / (2.0**(1. / bins_per_octave) - 1)
-    filter_cutoff = fmax_t*(1+1.0/Q)
-    nyquist = sr/2.0
+    filter_cutoff = fmax_t*(1 + 0.725 / Q) # 0.725 for Hann window
+    nyquist = sr / 2.0
 
     if filter_cutoff < 0.8*nyquist:
         res_type = 'sinc_fastest'

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -3,6 +3,7 @@
 '''Pitch-tracking and tuning estimation'''
 
 import numpy as np
+import warnings
 
 from . import audio
 from .time_frequency import cqt_frequencies, note_to_hz
@@ -153,8 +154,8 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     elif filter_cutoff < 0.97*nyquist:
         res_type = 'sinc_best'
     else:
-        ValueError("Highest frequency filter lies beyond Nyquist")
-
+        res_type = 'sinc_best'
+        warnings.warn("Filter passband lies beyond resampling bandwidth")
 
 
     # Generate the basis filters

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -113,7 +113,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     Raises
     ------
     ValueError
-        If `hop_length < 2**(n_bins / bins_per_octvae)`
+        If `hop_length < 2**(n_bins / bins_per_octave)`
 
     See Also
     --------
@@ -146,7 +146,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     # Determine required resampling quality
     Q = float(resolution) / (2.0**(1. / bins_per_octave) - 1)
-    filter_cutoff = fmax_t*(1 + 0.725 / Q) # 0.725 for Hann window
+    filter_cutoff = fmax_t*(1 + filters.HANN_BW / Q)
     nyquist = sr / 2.0
 
     if filter_cutoff < audio.BW_FASTEST*nyquist:
@@ -221,7 +221,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         fmax_t /= 2
         n_octaves -= 1
 
-        filter_cutoff = fmax_t*(1 + 0.725 / Q) # 0.725 for Hann window
+        filter_cutoff = fmax_t*(1 + filters.HANN_BW / Q)
         assert filter_cutoff < audio.BW_FASTEST*nyquist
 
         res_type = 'sinc_fastest'

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -467,7 +467,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
     for i in np.arange(n_bins, dtype=float):
 
         freq = fmin * 2.0**(i / bins_per_octave)
-        if freq * (1 + 1.0 / Q) > sr / 2.0:
+        if freq * (1 + 0.725 / Q) > sr / 2.0: # 0.725 for Hann window
             raise ValueError("Filter pass band lies beyond Nyquist")
 
         # Length of the filter

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -11,6 +11,8 @@ from . import util
 from .core.time_frequency import note_to_hz, hz_to_octs
 from .core.time_frequency import fft_frequencies, mel_frequencies
 
+HANN_BW = 0.725
+
 
 @cache
 def dct(n_filters, n_input):
@@ -467,7 +469,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
     for i in np.arange(n_bins, dtype=float):
 
         freq = fmin * 2.0**(i / bins_per_octave)
-        if freq * (1 + 0.725 / Q) > sr / 2.0: # 0.725 for Hann window
+        if freq * (1 + HANN_BW / Q) > sr / 2.0:
             raise ValueError("Filter pass band lies beyond Nyquist")
 
         # Length of the filter


### PR DESCRIPTION
See #154 .

This automatically detects the required resampling quality.  Using 'sinc_best' is really slow.  If we can get away with 'sinc_fastest' we should use it.

I have two concerns:
1. What is the upper passband limit of the highest frequency filter?  `fmax*(1+1/Q)` or `fmax*(1+0.5/Q)`?
2. What happens when scikits.samplerate isn't available?



