### PR TITLE
Hybrid-CQT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ pip-log.txt
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Vim
+*.swp

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -227,6 +227,248 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     return __trim_stack(cqt_resp, n_bins)
 
+@cache
+def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
+        bins_per_octave=12, tuning=None, resolution=2, res_type='sinc_best',
+        norm=2, sparsity=0.01):
+    '''Compute the hybrid constant-Q transform of an audio signal.
+
+    Here, the hybrid CQT uses the pseudo CQT for higher frequencies and
+    the full CQT for lower frequencies.
+
+    This implementation is based on the recursive sub-sampling method
+    described by [1]_.
+
+    .. [1] Schoerkhuber, Christian, and Anssi Klapuri.
+        "Constant-Q transform toolbox for music processing."
+        7th Sound and Music Computing Conference, Barcelona, Spain. 2010.
+
+    Parameters
+    ----------
+    y : np.ndarray [shape=(n,)]
+        audio time series
+
+    sr : int > 0 [scalar]
+        sampling rate of `y`
+
+    hop_length : int > 0 [scalar]
+        number of samples between successive CQT columns.
+
+    fmin : float > 0 [scalar]
+        Minimum frequency. Defaults to C2 ~= 32.70 Hz
+
+    n_bins : int > 0 [scalar]
+        Number of frequency bins, starting at `fmin`
+
+    bins_per_octave : int > 0 [scalar]
+        Number of bins per octave
+
+    tuning : None or float in `[-0.5, 0.5)`
+        Tuning offset in fractions of a bin (cents).
+
+        If `None`, tuning will be automatically estimated.
+
+    resolution : float > 0
+        Filter resolution factor. Larger values use longer windows.
+
+    sparsity : float in [0, 1)
+        Sparsify the CQT basis by discarding up to `sparsity`
+        fraction of the energy in each basis.
+
+        Set `sparsity=0` to disable sparsification.
+
+    Returns
+    -------
+    CQT : np.ndarray [shape=(n_bins, t), dtype=np.float]
+        Constant-Q energy for each frequency at each time.
+
+    Raises
+    ------
+    ValueError
+        If `hop_length < 2**(n_bins / bins_per_octave)`
+
+    See Also
+    --------
+    librosa.core.resample
+    librosa.util.normalize
+    '''
+
+    # How many octaves are we dealing with?
+    n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))
+
+    # Make sure our hop is long enough to support the bottom octave
+    if hop_length < 2**n_octaves:
+        raise ValueError('Insufficient hop_length {:d} '
+                         'for {:d} octaves'.format(hop_length, n_octaves))
+
+    if fmin is None:
+        # C2 by default
+        fmin = note_to_hz('C2')
+
+    if tuning is None:
+        tuning = estimate_tuning(y=y, sr=sr)
+
+    # Get all CQT frequencies
+    freqs = cqt_frequencies(n_bins, fmin,
+                            bins_per_octave=bins_per_octave)
+
+    # Compute the length of each constant-Q basis function
+    lengths = filters.constant_q_lengths(sr,
+                                         fmin=fmin,
+                                         n_bins=n_bins,
+                                         bins_per_octave=bins_per_octave,
+                                         tuning=tuning,
+                                         resolution=resolution)
+
+    # Determine which filters to use with Pseudo CQT
+    lengths = np.asarray(lengths)
+    pseudo_filters = lengths < 2*hop_length
+    n_bins_pseudo = np.sum(pseudo_filters)
+
+    cqt_resp = []
+
+    if n_bins_pseudo > 0:
+        fmin_pseudo = np.min(freqs[pseudo_filters])
+        my_pseudo_cqt = pseudo_cqt(y, sr,
+                                   hop_length=hop_length,
+                                   fmin=fmin_pseudo,
+                                   n_bins=n_bins_pseudo,
+                                   bins_per_octave=bins_per_octave,
+                                   tuning=tuning,
+                                   resolution=resolution,
+                                   norm=norm,
+                                   sparsity=sparsity)
+        cqt_resp.append(my_pseudo_cqt)
+
+    n_bins_full = np.sum(~pseudo_filters)
+
+    if n_bins_full > 0:
+
+        fmin_full = np.min(freqs[~pseudo_filters])
+
+        my_cqt = cqt(y, sr,
+                     hop_length=hop_length,
+                     fmin=fmin_full,
+                     n_bins=n_bins_full,
+                     bins_per_octave=bins_per_octave,
+                     tuning=tuning,
+                     resolution=resolution,
+                     norm=norm,
+                     sparsity=sparsity)
+
+        cqt_resp.append(my_cqt)
+
+
+    return __trim_stack(cqt_resp, n_bins)
+
+@cache
+def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
+        bins_per_octave=12, tuning=None, resolution=2,
+        norm=2, sparsity=0.01):
+    '''Compute the pseudo constant-Q transform of an audio signal.
+
+    This uses an fft size that is the smallest power of 2 that is greater than
+    or equal to the longest CQT filter.
+
+    Parameters
+    ----------
+    y : np.ndarray [shape=(n,)]
+        audio time series
+
+    sr : int > 0 [scalar]
+        sampling rate of `y`
+
+    hop_length : int > 0 [scalar]
+        number of samples between successive CQT columns.
+
+    fmin : float > 0 [scalar]
+        Minimum frequency. Defaults to C2 ~= 32.70 Hz
+
+    n_bins : int > 0 [scalar]
+        Number of frequency bins, starting at `fmin`
+
+    bins_per_octave : int > 0 [scalar]
+        Number of bins per octave
+
+    tuning : None or float in `[-0.5, 0.5)`
+        Tuning offset in fractions of a bin (cents).
+
+        If `None`, tuning will be automatically estimated.
+
+    resolution : float > 0
+        Filter resolution factor. Larger values use longer windows.
+
+    sparsity : float in [0, 1)
+        Sparsify the CQT basis by discarding up to `sparsity`
+        fraction of the energy in each basis.
+
+        Set `sparsity=0` to disable sparsification.
+
+    Returns
+    -------
+    CQT : np.ndarray [shape=(n_bins, t), dtype=np.float]
+        Constant-Q energy for each frequency at each time.
+
+    Raises
+    ------
+    ValueError
+        If `hop_length < 2**(n_bins / bins_per_octave)`
+
+    See Also
+    --------
+    librosa.core.resample
+    librosa.feature.sync
+    '''
+
+    if fmin is None:
+        # C2 by default
+        fmin = note_to_hz('C2')
+
+    if tuning is None:
+        tuning = estimate_tuning(y=y, sr=sr)
+
+
+    # Generate the pseudo CQT basis filters
+    basis = filters.constant_q(sr,
+                               fmin=fmin,
+                               n_bins=n_bins,
+                               bins_per_octave=bins_per_octave,
+                               tuning=tuning,
+                               resolution=resolution,
+                               pad_fft=True,
+                               norm=norm)
+
+    # Filters are padded up to the nearest integral power of 2
+    n_fft = basis.shape[1]
+
+    if n_fft < 2*hop_length:
+        n_fft = int(2.0**(np.ceil(np.log2(2*hop_length))))
+
+
+    # FFT and retain only the non-negative frequencies
+    fft_basis = np.fft.fft(basis, n=n_fft, axis=1)[:, :(n_fft / 2)+1]
+
+    # normalize as in Parseval's relation, and sparsify the basis
+    fft_basis = util.sparsify_rows(fft_basis / n_fft, quantile=sparsity)
+
+    # Remove phase for Pseudo CQT
+    fft_basis = np.abs(fft_basis)
+
+    # Get all CQT frequencies
+    freqs = cqt_frequencies(n_bins, fmin,
+                            bins_per_octave=bins_per_octave, tuning=tuning)
+
+
+    # Compute the STFT matrix with Hann window
+    D = stft(y, n_fft=n_fft, hop_length=int(hop_length))
+
+    # Remove phase for Pseudo CQT
+    D = np.abs(D)
+
+    my_pseudo_cqt = np.abs(fft_basis.dot(D))
+
+    return my_pseudo_cqt
+
 
 def __fft_filters(sr, fmin, bins_per_octave, tuning,
                   resolution, norm, sparsity):

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -13,7 +13,7 @@ from .. import filters
 from .. import util
 from ..feature.utils import sync
 
-__all__ = ['cqt']
+__all__ = ['cqt', 'hybrid_cqt', 'pseudo_cqt']
 
 
 @cache
@@ -233,15 +233,9 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                norm=2, sparsity=0.01):
     '''Compute the hybrid constant-Q transform of an audio signal.
 
-    Here, the hybrid CQT uses the pseudo CQT for higher frequencies and
-    the full CQT for lower frequencies.
-
-    This implementation is based on the recursive sub-sampling method
-    described by [1]_.
-
-    .. [1] Schoerkhuber, Christian, and Anssi Klapuri.
-        "Constant-Q transform toolbox for music processing."
-        7th Sound and Music Computing Conference, Barcelona, Spain. 2010.
+    Here, the hybrid CQT uses the pseudo CQT for higher frequencies where
+    the hop_length is longer than half the filter length and the full CQT
+    for lower frequencies.
 
     Parameters
     ----------
@@ -289,7 +283,6 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     See Also
     --------
-    librosa.core.resample
     librosa.util.normalize
     '''
 
@@ -367,8 +360,10 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                norm=2, sparsity=0.01):
     '''Compute the pseudo constant-Q transform of an audio signal.
 
-    This uses an fft size that is the smallest power of 2 that is greater than
-    or equal to the longest CQT filter.
+    This uses a single fft size that is the smallest power of 2 that is greater
+    than or equal to the max of:
+        1. The longest CQT filter
+        2. 2x the hop_length
 
     Parameters
     ----------
@@ -407,17 +402,13 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     Returns
     -------
     CQT : np.ndarray [shape=(n_bins, t), dtype=np.float]
-        Constant-Q energy for each frequency at each time.
+        Pseudo Constant-Q energy for each frequency at each time.
 
     Raises
     ------
     ValueError
         If `hop_length < 2**(n_bins / bins_per_octave)`
 
-    See Also
-    --------
-    librosa.core.resample
-    librosa.feature.sync
     '''
 
     if fmin is None:

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -528,6 +528,66 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
     else:
         return filters
 
+@cache
+def constant_q_lengths(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
+                       resolution=2):
+    r'''Return lengths of each filter in a constant-Q basis
+
+
+    Parameters
+    ----------
+    sr : int > 0 [scalar]
+        Audio sampling rate
+
+    fmin : float > 0 [scalar]
+        Minimum frequency bin. Defaults to `C2 ~= 32.70`
+
+    n_bins : int > 0 [scalar]
+        Number of frequencies.  Defaults to 7 octaves (84 bins).
+
+    bins_per_octave : int > 0 [scalar]
+        Number of bins per octave
+
+    tuning : float in `[-0.5, +0.5)` [scalar]
+        Tuning deviation from A440 in fractions of a bin
+
+    resolution : float > 0 [scalar]
+        Resolution of filter windows. Larger values use longer windows.
+
+    Returns
+    -------
+    lengths : np.ndarray
+        The length of each filter.
+
+    See Also
+    --------
+    librosa.core.cqt
+    '''
+
+    if fmin is None:
+        fmin = note_to_hz('C2')
+
+    correction = 2.0**(float(tuning) / bins_per_octave)
+
+    fmin = correction * fmin
+
+    # Q should be capitalized here, so we suppress the name warning
+    # pylint: disable=invalid-name
+    Q = float(resolution) / (2.0**(1. / bins_per_octave) - 1)
+
+    lengths = []
+    for i in np.arange(n_bins, dtype=float):
+
+        freq = fmin * 2.0**(i / bins_per_octave)
+        if freq * (1 + HANN_BW / Q) > sr / 2.0:
+            raise ValueError("Filter pass band lies beyond Nyquist")
+
+        # Length of the filter
+        ilen = Q * sr / freq
+        lengths.append(ilen)
+
+    return lengths
+
 
 @cache
 def cq_to_chroma(n_input, bins_per_octave=12, n_chroma=12, roll=0):

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -579,7 +579,7 @@ def constant_q_lengths(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
     for i in np.arange(n_bins, dtype=float):
 
         freq = fmin * 2.0**(i / bins_per_octave)
-        if freq * (1 + HANN_BW / Q) > sr / 2.0:
+        if freq * (1 + window_bandwidth('hann') / Q) > sr / 2.0:
             raise ValueError("Filter pass band lies beyond Nyquist")
 
         # Length of the filter


### PR DESCRIPTION
This adds a hybrid_cqt which is a combination of a pseduo-cqt and the full-cqt.  The full-cqt does oversampling and then aggregation when the hop_length is longer than half the shortest filter.  The hybrid-cqt avoids this computationally complex step by just doing a pseudo CQT for such filters.  (The pseudo-cqt being the phase invariant CQT that uses the both the magnitude of the filters and the magnitude of the stft.).  The filters that are longer than twice the hop_length are then carried out using the full-cqt.  

This is not meant to produce equivalent output to a full-cqt, but it is quite a bit faster when the highest octave would require a very small oversampling hop.