### PR TITLE
Changing peak pick boundary logic

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -354,8 +354,6 @@ def test_peak_pick():
 
         # Generate a test signal
         x = np.random.randn(n)**2
-        x_mean = np.pad(x, (pre_avg, post_avg), mode='edge')
-        x_max = np.pad(x, (pre_max, post_max), mode='edge')
 
         peaks = librosa.util.peak_pick(x,
                                        pre_max, post_max,
@@ -367,26 +365,27 @@ def test_peak_pick():
 
         for i in peaks:
             # Test 1: is it a peak in this window?
-            i_max = i + pre_max
-            s = i_max - pre_max
-            t = i_max + post_max
+            s = i - pre_max
+            if s < 0:
+                s = 0
+            t = i + post_max
 
-            print i, i_max, s, t
-            print 'Peak: {:.3e}, max: {:.3e}'.format(x[i], np.max(x_max[s:t]))
-            diff = x[i] - np.max(x_max[s:t])
+            print i, s, t
+            print 'Peak: {:.3e}, max: {:.3e}'.format(x[i], np.max(x[s:t]))
+            diff = x[i] - np.max(x[s:t])
             print diff
             assert diff > 0 or np.isclose(diff, 0)
 
             # Test 2: is it a big enough peak to count?
-            i_avg = i + pre_avg
-            s = i_avg - pre_avg
-            t = i_avg + post_avg
+            s = i - pre_avg
+            if s < 0:
+                s = 0
+            t = i + post_avg
 
-            print i, i_avg, s, t
-            print 'Peak: {:.3e}, mean: {:.3e}, delta: {:.3e}'.format(x[i],
-                                                                     np.mean(x_mean[s:t]),
-                                                                     delta)
-            diff = x[i] - (delta + np.mean(x_mean[s:t]))
+            print i, s, t
+            print 'Peak: {:.3e}, mean: {:.3e}, delta: {:.3e}'.format(
+                x[i], np.mean(x[s:t]), delta)
+            diff = x[i] - (delta + np.mean(x[s:t]))
             print diff
             assert diff > 0 or np.isclose(diff, 0)
 


### PR DESCRIPTION
Based on my interpretation of the spec, here's how I think it should work when the window overlaps at the edges:
```
|------filter------|
     |------signal-------
```
should actually compute
```
     |--filter------|
     |------signal-------
```  

To achieve this behavior, for both of the filters, I changed the origin logic to include a `ceil`.  I changed the maximum filter to use constant edge padding with `x.min()` which does the right thing.  There's no edge mode I could find which does the right thing for the mean filter, so I just used `'nearest'` and then corrected the overlapping portions manually.  I changed the tests to reflect my understanding of what it should do.  It passes my test for all cases now.