### PR TITLE
Removed unused 'import os' from LibROSA demo.ipynb example

### DIFF
--- a/examples/LibROSA demo.ipynb
+++ b/examples/LibROSA demo.ipynb
@@ -26,10 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "# We'll need the os module for file path manipulation\n",
-    "import os\n",
-    "\n",
-    "# And numpy for some mathematical operations\n",
+    "# We'll need numpy for some mathematical operations\n",
     "import numpy as np\n",
     "\n",
     "# Librosa for audio\n",


### PR DESCRIPTION
Small thing here. I removed the "import os" from "LibROSA demo", as it's not used anywhere else in the file.