### PR TITLE
added ability to change window type in chroma_stft and _spectogram

### DIFF
--- a/librosa/core/spectrum.py
+++ b/librosa/core/spectrum.py
@@ -730,7 +730,7 @@ def perceptual_weighting(S, frequencies, **kwargs):
 
 
 @cache
-def _spectrogram(y=None, S=None, n_fft=2048, hop_length=512, power=1):
+def _spectrogram(y=None, S=None, window=None, n_fft=2048, hop_length=512, power=1):
     '''Helper function to retrieve a magnitude spectrogram.
 
     This is primarily used in feature extraction functions that can operate on
@@ -744,6 +744,12 @@ def _spectrogram(y=None, S=None, n_fft=2048, hop_length=512, power=1):
 
     S : None or np.ndarray
         Spectrogram input, optional
+        
+    window : None, function, np.ndarray [shape=(n_fft,)]
+        STFT window type
+        - None (default): use an asymmetric Hann window
+        - a window function, such as `scipy.signal.hann`
+        - a vector or array of length `n_fft`
 
     n_fft : int > 0
         STFT window size
@@ -771,6 +777,6 @@ def _spectrogram(y=None, S=None, n_fft=2048, hop_length=512, power=1):
         n_fft = 2 * (S.shape[0] - 1)
     else:
         # Otherwise, compute a magnitude spectrogram from input
-        S = np.abs(stft(y, n_fft=n_fft, hop_length=hop_length))**power
+        S = np.abs(stft(y, window=window, n_fft=n_fft, hop_length=hop_length))**power
 
     return S, n_fft

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -716,7 +716,7 @@ def zero_crossing_rate(y, frame_length=2048, hop_length=512, center=True,
 
 # -- Chroma --#
 @cache
-def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
+def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, window=None, n_fft=2048,
                 hop_length=512, tuning=None, **kwargs):
     """Compute a chromagram from an STFT spectrogram or waveform
 
@@ -736,6 +736,12 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
         See `librosa.util.normalize` for details.
 
         If `None`, no normalization is performed.
+    
+    window : None, function, np.ndarray [shape=(n_fft,)]
+        STFT window type
+        - None (default): use an asymmetric Hann window
+        - a window function, such as `scipy.signal.hann`
+        - a vector or array of length `n_fft`
 
     n_fft : int  > 0 [scalar]
         FFT window size if provided `y, sr` instead of `S`
@@ -792,8 +798,8 @@ def chroma_stft(y=None, sr=22050, S=None, norm=np.inf, n_fft=2048,
 
     """
 
-    S, n_fft = _spectrogram(y=y, S=S, n_fft=n_fft, hop_length=hop_length,
-                            power=2)
+    S, n_fft = _spectrogram(y=y, S=S, window=window, n_fft=n_fft,
+                            hop_length=hop_length, power=2)
 
     n_chroma = kwargs.get('n_chroma', 12)
 


### PR DESCRIPTION
Hi Brian,

While calling the chroma_stft function I noticed that you cannot change the window type, say from the default hann to blackmannharris.

I thought it would be nice to have the ability to do that, so I forked your code and edited the two files that needed to be edited.

In case you think it's also useful for the master branch, here's a pull request.