### PR TITLE
Fixed loading of audio files to make possible sample-accurate loading

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -108,12 +108,12 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
     with audioread.audio_open(os.path.realpath(path)) as input_file:
         sr_native = input_file.samplerate
 
-        s_start = int(np.floor(sr_native * offset)) * input_file.channels
+        s_start = int(np.round(sr_native * offset)) * input_file.channels
 
         if duration is None:
             s_end = np.inf
         else:
-            s_end = s_start + (int(np.ceil(sr_native * duration))
+            s_end = s_start + (int(np.round(sr_native * duration))
                                * input_file.channels)
 
         n = 0
@@ -136,7 +136,7 @@ def load(path, sr=22050, mono=True, offset=0.0, duration=None,
                 # the end is in this frame.  crop.
                 frame = frame[:s_end - n_prev]
 
-            if n_prev <= s_start < n:
+            if n_prev <= s_start <= n:
                 # beginning is in this frame
                 frame = frame[(s_start - n_prev):]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -56,6 +56,18 @@ def test_load():
         yield (__test, infile)
     pass
 
+def test_segment_load():
+    """
+    Test loading a segment. Check size accuracy
+    """
+
+    sample_len = 2003
+    y, sr = librosa.load('data/test1_44100.wav', sr=None, mono=False, offset=0., duration=sample_len/44100.)
+    assert y.shape[1] == sample_len
+
+    y, sr = librosa.load('data/test1_44100.wav', sr=None, mono=False, offset=2048/44100., duration=1.0)
+    assert y.shape[1] == 44100
+
 
 def test_resample():
 


### PR DESCRIPTION
There are two small modifications in the pull request: 
- the first one (l. 139) is a fix for a bug that appeared when s_start was a multiple of the size of the frame and that causes inaccurate duration for the loaded signal (loaded signal was in this case a frame too long). The bug can be reproduced by loading an audio file with an offset which is a multiple of the size of the frame (of the for loop l.121) when expressed in sample.
With ffmpeg backend for audioread, the following line returned a 1.023s long waveform x instead of a 1s long one (verified on both mac OS and Debian) :
x,sr = librosa.core.audio.load('test_signal.wav', sr=44100, offset=1024/44100., duration=1.0)
- the second modification (l.111 and 116) replaces ceil and floor by round for second to sample conversion which makes possible sample-accurate loading of audio files.