### PR TITLE
added CQT hop-length check to fix #208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changes
 ##v0.4.1
 
   - Rewrote `display.waveplot` for improved efficiency
+  - Improved safety check in CQT for invalid hop lengths
 
 ##v0.4.0
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -81,7 +81,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     Raises
     ------
     ParameterError
-        If `hop_length < 2**(n_bins / bins_per_octave)`
+        If `hop_length` is not an integer multiple of `2**(n_bins / bins_per_octave)`
 
     See Also
     --------
@@ -131,9 +131,9 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))
 
     # Make sure our hop is long enough to support the bottom octave
-    if hop_length < 2**n_octaves:
-        raise ParameterError('Insufficient hop_length {:d} '
-                             'for {:d} octaves'.format(hop_length, n_octaves))
+    if np.mod(hop_length, 2**n_octaves) != 0:
+        raise ParameterError('hop_length must be an integer multiple of 2^{0:d} '
+                             'for {0:d}-octave CQT'.format(n_octaves))
 
     if fmin is None:
         # C2 by default
@@ -291,7 +291,7 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     Raises
     ------
     ParameterError
-        If `hop_length < 2**(n_bins / bins_per_octave)`
+        If `hop_length` is not an integer multiple of `2**(n_bins / bins_per_octave)`
 
     See Also
     --------
@@ -303,9 +303,9 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))
 
     # Make sure our hop is long enough to support the bottom octave
-    if hop_length < 2**n_octaves:
-        raise ParameterError('Insufficient hop_length {:d} '
-                             'for {:d} octaves'.format(hop_length, n_octaves))
+    if np.mod(hop_length, 2**n_octaves) != 0:
+        raise ParameterError('hop_length must be an integer multiple of 2^{0:d} '
+                             'for {0:d}-octave CQT'.format(n_octaves))
 
     if fmin is None:
         # C1 by default
@@ -420,7 +420,7 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     Raises
     ------
     ParameterError
-        If `hop_length < 2**(n_bins / bins_per_octave)`
+        If `hop_length` is not an integer multiple of `2**(n_bins / bins_per_octave)`
 
     '''
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -131,8 +131,8 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))
 
     # Make sure our hop is long enough to support the bottom octave
-    if np.mod(hop_length, 2**n_octaves) != 0:
-        raise ParameterError('hop_length must be an integer multiple of 2^{0:d} '
+    if np.mod(hop_length, 2**n_octaves) != 0 or hop_length < 2**n_octaves:
+        raise ParameterError('hop_length must be a positive integer multiple of 2^{0:d} '
                              'for {0:d}-octave CQT'.format(n_octaves))
 
     if fmin is None:
@@ -303,8 +303,8 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))
 
     # Make sure our hop is long enough to support the bottom octave
-    if np.mod(hop_length, 2**n_octaves) != 0:
-        raise ParameterError('hop_length must be an integer multiple of 2^{0:d} '
+    if np.mod(hop_length, 2**n_octaves) != 0 or hop_length < 2**n_octaves:
+        raise ParameterError('hop_length must be a positive integer multiple of 2^{0:d} '
                              'for {0:d}-octave CQT'.format(n_octaves))
 
     if fmin is None:

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -51,10 +51,11 @@ def test_cqt():
     y[::sr] = 1.0
 
 
-    # Hop size not long enough for num octaves
+    # incorrect hop length for a 6-octave analysis
     # num_octaves = 6, 2**6 = 64 > 32
-    yield (raises(librosa.ParameterError)(__test_cqt_size), y, sr, 32, None, 72,
-           12, 0.0, 2, None, 1, 0.01)
+    for hop_length in [32, 63, 65]:
+        yield (raises(librosa.ParameterError)(__test_cqt_size), y, sr, hop_length, None, 72,
+               12, 0.0, 2, None, 1, 0.01)
 
     # Filters go beyond Nyquist. 500 Hz -> 4 octaves = 8000 Hz > 11000 Hz
     yield (raises(librosa.ParameterError)(__test_cqt_size), y, sr, 512, 500, 48,

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -53,7 +53,7 @@ def test_cqt():
 
     # incorrect hop length for a 6-octave analysis
     # num_octaves = 6, 2**6 = 64 > 32
-    for hop_length in [32, 63, 65]:
+    for hop_length in [-1, 0, 32, 63, 65]:
         yield (raises(librosa.ParameterError)(__test_cqt_size), y, sr, hop_length, None, 72,
                12, 0.0, 2, None, 1, 0.01)
 


### PR DESCRIPTION
Fixes #208 by adding a safety check for `hop_length % n * 2**n_octaves == 0`.