### PR TITLE
Change inf to np.inf

### DIFF
--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -578,9 +578,9 @@ def normalize(S, norm=np.inf, axis=0):
     S : np.ndarray [shape=(d, n)]
         The matrix to normalize
 
-    norm : {inf, -inf, 0, float > 0, None}
-        - `inf`  : maximum absolute value
-        - `-inf` : mininum absolute value
+    norm : {np.inf, -np.inf, 0, float > 0, None}
+        - `np.inf`  : maximum absolute value
+        - `-np.inf` : mininum absolute value
         - `0`    : number of non-zeros
         - float  : corresponding l_p norm.
             See `scipy.linalg.norm` for details.


### PR DESCRIPTION
In the docstring for `util.normalize`, it currently states that `inf` and `-inf` are options corresponding to the maximum and minimum absolute values respectively.  But, `inf` is not a built-in type, it's a member of `numpy`.  For consistency (e.g. `np.ndarray` types elsewhere in docstrings) and clarity (I thought for a minute I was supposed to pass the string `'inf'`), I'd suggest they be changed to `np.inf`.