### PR TITLE
Address additional CQT hop_length concerns

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -226,7 +226,8 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         if i > 0:
             my_y = audio.resample(my_y, my_sr, my_sr/2.0, res_type=res_type)
             my_sr = my_sr / 2.0
-            my_hop = int(my_hop / 2.0)
+            assert my_hop % 2 == 0
+            my_hop //= 2
 
         # Compute a dynamic hop based on n_fft
         my_cqt = __variable_hop_response(my_y, n_fft,
@@ -542,6 +543,7 @@ def __early_downsample(y, sr, hop_length, res_type, n_octaves,
     if downsample_count > 0:
         downsample_factor = 2**(downsample_count)
 
+        assert hop_length % downsample_factor == 0
         hop_length = hop_length // downsample_factor
 
         y = audio.resample(y, sr, sr / downsample_factor, res_type=res_type)

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -201,9 +201,10 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         res_type = 'sinc_fastest'
 
     # Make sure our hop is long enough to support the bottom octave
-    if np.mod(hop_length, 2**n_octaves) != 0 or hop_length < 2**n_octaves:
+    num_twos = __num_two_factors(hop_length)
+    if num_twos < n_octaves - 1:
         raise ParameterError('hop_length must be a positive integer multiple of 2^{0:d} '
-                            'for {0:d}-octave CQT'.format(n_octaves))
+                            'for {1:d}-octave CQT'.format(n_octaves - 1, n_octaves))
 
     # Now do the recursive bit
     fft_basis, n_fft, filter_lengths = __fft_filters(sr, fmin_t,
@@ -302,11 +303,6 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     # How many octaves are we dealing with?
     n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))
-
-    # Make sure our hop is long enough to support the bottom octave
-    if np.mod(hop_length, 2**n_octaves) != 0 or hop_length < 2**n_octaves:
-        raise ParameterError('hop_length must be a positive integer multiple of 2^{0:d} '
-                             'for {0:d}-octave CQT'.format(n_octaves))
 
     if fmin is None:
         # C1 by default

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -225,7 +225,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         # Resample (except first time)
         if i > 0:
             my_y = audio.resample(my_y, my_sr, my_sr/2.0, res_type=res_type)
-            my_sr = my_sr / 2.0
+            my_sr /= 2.0
             assert my_hop % 2 == 0
             my_hop //= 2
 
@@ -544,11 +544,11 @@ def __early_downsample(y, sr, hop_length, res_type, n_octaves,
         downsample_factor = 2**(downsample_count)
 
         assert hop_length % downsample_factor == 0
-        hop_length = hop_length // downsample_factor
+        hop_length //= downsample_factor
 
         y = audio.resample(y, sr, sr / downsample_factor, res_type=res_type)
 
-        sr = sr // downsample_factor
+        sr /= downsample_factor
 
     return y, sr, hop_length
 

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -52,8 +52,8 @@ def test_cqt():
 
 
     # incorrect hop length for a 6-octave analysis
-    # num_octaves = 6, 2**6 = 64 > 32
-    for hop_length in [-1, 0, 32, 63, 65]:
+    # num_octaves = 6, 2**(6-1) = 32 > 16
+    for hop_length in [-1, 0, 16, 63, 65]:
         yield (raises(librosa.ParameterError)(__test_cqt_size), y, sr, hop_length, None, 72,
                12, 0.0, 2, None, 1, 0.01)
 

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -112,11 +112,6 @@ def test_hybrid_cqt():
         # Check for numerical comparability
         assert np.mean(np.abs(C1 - C2)) < 1e-3
 
-    # Hop size not long enough for num octaves
-    # num_octaves = 6, 2**(72/12) = 64 > 32
-    yield (raises(librosa.ParameterError)(__test), 32, None, 72,
-           12, 0.0, 2, 1, 0.01)
-
     for fmin in [None, librosa.note_to_hz('C2')]:
         for n_bins in [1, 12, 24, 48, 72, 74, 76]:
             for bins_per_octave in [12, 24]:


### PR DESCRIPTION
This takes early-downsampling and two-octaves-before-downsampling into account when checking that `hop_length` constraints are met.  

I'm also assuming that `hop_length` only needs to be divisible by `2**(n_octaves-1)` since that is how many times we'd need to downsample.  Not sure if that's a valid assumption since the previous criterion was `hop_length >= 2**n_octaves`.  