### PR TITLE
#236 autocorrelate now operates on any axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changes
   - Nullified side-effects of optional seaborn dependency
   - Moved `feature.sync` to `util.sync` and expanded its functionality
   - `librosa.onset.onset_strength` and `onset_strength_multi` support superflux-style lag and max-filtering
+  - `librosa.core.autocorrelate` can now operate along any axis of multi-dimensional input
 
 New features
   - `librosa.clicks` sonifies timed events such as beats or onsets


### PR DESCRIPTION
This pr implements axis-agnostic autocorrelation.

As an added bonus, the unit tests have been enhanced to compare for numerical precision against `scipy.signal.fftconvolve`.