### PR TITLE
[WIP] onset_strength alignment and centering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changes
   - Added proper window normalization to `librosa.core.istft` for better reconstruction ([#235]).
   - Fixed division by zero bug in `core.pitch.pip_track`
   - Standardized `n_fft=2048` for `piptrack`, `ifptrack` (deprecated), and `logfsgram` (deprecated)
+  - `onset_strength` parameter `'centering'` has been deprecated and renamed to `'center'`
+  - `onset_strength` always trims to match the input spectrogram duration
 
 New features
   - `librosa.clicks` sonifies timed events such as beats or onsets

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -81,7 +81,7 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> hop_length = 512
     >>> oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length,
-    ...                                     centering=False)
+    ...                                     center=False)
     >>> tempogram = librosa.feature.tempogram(onset_envelope=oenv, sr=sr,
     ...                                       hop_length=hop_length)
     >>> # Compute global onset autocorrelation
@@ -132,7 +132,7 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
 
         onset_envelope = onset_strength(y=y, sr=sr,
                                         hop_length=hop_length,
-                                        centering=False)
+                                        center=False)
 
     # Pad the envelope so that autocorrelation windows are centered on the input
     n = len(onset_envelope)

--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -80,8 +80,7 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
     >>> # Compute local onset autocorrelation
     >>> y, sr = librosa.load(librosa.util.example_audio_file())
     >>> hop_length = 512
-    >>> oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length,
-    ...                                     center=False)
+    >>> oenv = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop_length)
     >>> tempogram = librosa.feature.tempogram(onset_envelope=oenv, sr=sr,
     ...                                       hop_length=hop_length)
     >>> # Compute global onset autocorrelation
@@ -131,8 +130,7 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
             raise ParameterError('Either y or onset_envelope must be provided')
 
         onset_envelope = onset_strength(y=y, sr=sr,
-                                        hop_length=hop_length,
-                                        center=False)
+                                        hop_length=hop_length)
 
     # Pad the envelope so that autocorrelation windows are centered on the input
     n = len(onset_envelope)

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -422,8 +422,13 @@ def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
     # Ensure that S is at least 2-d
     S = np.atleast_2d(S)
 
-    # Compute the reference spectrogram
-    ref_spec = scipy.ndimage.maximum_filter1d(S, max_size, axis=0)
+    # Compute the reference spectrogram.
+    # Efficiency hack: skip filtering step and pass by reference
+    # if max_size will produce a no-op.
+    if max_size == 1:
+        ref_spec = S
+    else:
+        ref_spec = scipy.ndimage.maximum_filter1d(S, max_size, axis=0)
 
     # Compute difference to the reference, spaced by lag
     onset_env = S[:, lag:] - ref_spec[:, :-lag]

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -13,6 +13,7 @@ Onset detection
 
 import numpy as np
 import scipy
+import six
 import warnings
 
 from . import cache
@@ -278,11 +279,11 @@ def onset_strength(y=None, sr=22050, S=None, lag=1, max_size=1,
 
     if centering is not None:
         center = centering
-        warnings.warn_explicit("The 'centering=' parameter of onset_strength is "
-                               "deprecated as of librosa version 0.4.1."
-                               "\n\tIt will be removed in librosa version 0.5.0."
-                               "\n\tPlease use 'center=' instead.",
-                               category=DeprecationWarning)
+        warnings.warn("The 'centering=' parameter of onset_strength is "
+                      "deprecated as of librosa version 0.4.1."
+                      "\n\tIt will be removed in librosa version 0.5.0."
+                      "\n\tPlease use 'center=' instead.",
+                      category=DeprecationWarning)
 
     odf_all = onset_strength_multi(y=y,
                                    sr=sr,

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -13,6 +13,7 @@ Onset detection
 
 import numpy as np
 import scipy
+import warnings
 
 from . import cache
 from . import core
@@ -145,8 +146,10 @@ def onset_detect(y=None, sr=22050, onset_envelope=None, hop_length=512,
 
 
 def onset_strength(y=None, sr=22050, S=None, lag=1, max_size=1,
-                   detrend=False, centering=True,
-                   feature=None, aggregate=None, **kwargs):
+                   detrend=False, center=True,
+                   feature=None, aggregate=None,
+                   centering=None,
+                   **kwargs):
     """Compute a spectral flux onset strength envelope.
 
     Onset strength at time `t` is determined by:
@@ -185,8 +188,12 @@ def onset_strength(y=None, sr=22050, S=None, lag=1, max_size=1,
     detrend : bool [scalar]
         Filter the onset strength to remove the DC component
 
-    centering : bool [scalar]
+    center : bool [scalar]
+    centering : bool [scalar] (deprecated)
         Shift the onset function by `n_fft / (2 * hop_length)` frames
+
+        .. note:: The `centering` parameter is deprecated as of 0.4.1,
+        and has been replaced by the `center` parameter.
 
     feature : function
         Function for computing time-series features, eg, scaled spectrograms.
@@ -269,13 +276,21 @@ def onset_strength(y=None, sr=22050, S=None, lag=1, max_size=1,
 
     """
 
+    if centering is not None:
+        center = centering
+        warnings.warn_explicit("The 'centering=' parameter of onset_strength is "
+                               "deprecated as of librosa version 0.4.1."
+                               "\n\tIt will be removed in librosa version 0.5.0."
+                               "\n\tPlease use 'center=' instead.",
+                               category=DeprecationWarning)
+
     odf_all = onset_strength_multi(y=y,
                                    sr=sr,
                                    S=S,
                                    lag=lag,
                                    max_size=max_size,
                                    detrend=detrend,
-                                   centering=centering,
+                                   center=center,
                                    feature=feature,
                                    aggregate=aggregate,
                                    channels=None,
@@ -286,7 +301,7 @@ def onset_strength(y=None, sr=22050, S=None, lag=1, max_size=1,
 
 @cache
 def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1, 
-                         detrend=False, centering=True, feature=None,
+                         detrend=False, center=True, feature=None,
                          aggregate=None, channels=None, **kwargs):
     """Compute a spectral flux onset strength envelope across multiple channels.
 
@@ -316,7 +331,7 @@ def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
     detrend : bool [scalar]
         Filter the onset strength to remove the DC component
 
-    centering : bool [scalar]
+    center : bool [scalar]
         Shift the onset function by `n_fft / (2 * hop_length)` frames
 
     feature : function
@@ -429,7 +444,7 @@ def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
 
     # compensate for lag
     pad_width = lag
-    if centering:
+    if center:
         # Counter-act framing effects. Shift the onsets by n_fft / hop_length
         pad_width += n_fft // (2 * hop_length)
 

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -455,4 +455,8 @@ def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
     if detrend:
         onset_env = scipy.signal.lfilter([1.0, -1.0], [1.0, -0.99], onset_env, axis=-1)
 
+    # Trim to match the input duration
+    if center:
+        onset_env = onset_env[:, :S.shape[1]]
+
     return onset_env

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -33,7 +33,7 @@ def test_onset_strength():
                                               S=DATA['D'],
                                               lag=1,
                                               max_size=1,
-                                              centering=False,
+                                              center=False,
                                               detrend=True,
                                               aggregate=np.mean)
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -494,8 +494,7 @@ def test_tempogram_audio():
     for hop_length in [512, 1024]:
         oenv = librosa.onset.onset_strength(y=y,
                                             sr=sr,
-                                            hop_length=hop_length,
-                                            center=False)
+                                            hop_length=hop_length)
 
         yield __test, y, sr, oenv, hop_length
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -495,7 +495,7 @@ def test_tempogram_audio():
         oenv = librosa.onset.onset_strength(y=y,
                                             sr=sr,
                                             hop_length=hop_length,
-                                            centering=False)
+                                            center=False)
 
         yield __test, y, sr, oenv, hop_length
 

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -203,8 +203,6 @@ def test_onset_strength_deprecated():
         with warnings.catch_warnings(record=True) as out:
             librosa.onset.onset_strength(y=y, sr=sr, centering=centering)
 
-            print(centering, no_warning, out)
-
             if no_warning:
                 eq_(out, [])
             else:

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -46,8 +46,8 @@ def test_onset_strength_audio():
 
         target_shape = S.shape[-1]
 
-        if center:
-            target_shape += n_fft // (2 * hop_length)
+        #if center:
+        #    target_shape += n_fft // (2 * hop_length)
 
         if not detrend:
             assert np.all(oenv >= 0)
@@ -96,8 +96,8 @@ def test_onset_strength_spectrogram():
 
         target_shape = S.shape[-1]
 
-        if center:
-            target_shape += n_fft // (2 * hop_length)
+        #if center:
+        #    target_shape += n_fft // (2 * hop_length)
 
         if not detrend:
             assert np.all(oenv >= 0)

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -15,6 +15,8 @@ except:
 import matplotlib
 matplotlib.use('Agg')
 
+import warnings
+
 import numpy as np
 import librosa
 
@@ -186,3 +188,30 @@ def test_onset_detect_const():
                                                 sr=sr,
                                                 hop_length=hop_length)
             yield __test, y, sr, oenv, hop_length
+
+
+def test_onset_strength_deprecated():
+
+    y, sr = librosa.load(__EXAMPLE_FILE)
+
+    def __test(centering):
+
+        no_warning = (centering is None)
+
+        warnings.resetwarnings()
+        warnings.simplefilter('always')
+        with warnings.catch_warnings(record=True) as out:
+            librosa.onset.onset_strength(y=y, sr=sr, centering=centering)
+
+            print(centering, no_warning, out)
+
+            if no_warning:
+                eq_(out, [])
+            else:
+                assert len(out) > 0
+                assert out[0].category is DeprecationWarning
+                assert 'deprecated' in str(out[0].message).lower()
+
+
+    for centering in [True, False, None]:
+        yield __test, centering

--- a/tests/test_onset.py
+++ b/tests/test_onset.py
@@ -23,12 +23,12 @@ __EXAMPLE_FILE = 'data/test1_22050.wav'
 
 def test_onset_strength_audio():
 
-    def __test(y, sr, feature, n_fft, hop_length, lag, max_size, detrend, centering, aggregate):
+    def __test(y, sr, feature, n_fft, hop_length, lag, max_size, detrend, center, aggregate):
 
         oenv = librosa.onset.onset_strength(y=y, sr=sr,
                                             S=None,
                                             detrend=detrend,
-                                            centering=centering,
+                                            center=center,
                                             aggregate=aggregate,
                                             feature=feature,
                                             n_fft=n_fft,
@@ -44,7 +44,7 @@ def test_onset_strength_audio():
 
         target_shape = S.shape[-1]
 
-        if centering:
+        if center:
             target_shape += n_fft // (2 * hop_length)
 
         if not detrend:
@@ -62,7 +62,7 @@ def test_onset_strength_audio():
                 for lag in [0, 1, 2]:
                     for max_size in [0, 1, 2]:
                         for detrend in [False, True]:
-                            for centering in [False, True]:
+                            for center in [False, True]:
                                 for aggregate in [None, np.mean, np.max]:
                                     if lag < 1 or max_size < 1:
                                         tf = raises(librosa.ParameterError)(__test)
@@ -70,21 +70,21 @@ def test_onset_strength_audio():
                                         tf = __test
 
                                     yield (tf, y, sr, feature, n_fft,
-                                           hop_length, lag, max_size, detrend, centering, aggregate)
+                                           hop_length, lag, max_size, detrend, center, aggregate)
 
                                     tf = raises(librosa.ParameterError)(__test)
                                     yield (tf, None, sr, feature, n_fft,
-                                           hop_length, lag, max_size, detrend, centering, aggregate)
+                                           hop_length, lag, max_size, detrend, center, aggregate)
 
 
 def test_onset_strength_spectrogram():
 
-    def __test(S, sr, feature, n_fft, hop_length, detrend, centering):
+    def __test(S, sr, feature, n_fft, hop_length, detrend, center):
 
         oenv = librosa.onset.onset_strength(y=None, sr=sr,
                                             S=S,
                                             detrend=detrend,
-                                            centering=centering,
+                                            center=center,
                                             aggregate=aggregate,
                                             feature=feature,
                                             n_fft=n_fft,
@@ -94,7 +94,7 @@ def test_onset_strength_spectrogram():
 
         target_shape = S.shape[-1]
 
-        if centering:
+        if center:
             target_shape += n_fft // (2 * hop_length)
 
         if not detrend:
@@ -111,13 +111,13 @@ def test_onset_strength_spectrogram():
         for n_fft in [512, 2048]:
             for hop_length in [n_fft // 2, n_fft // 4]:
                 for detrend in [False, True]:
-                    for centering in [False, True]:
+                    for center in [False, True]:
                         for aggregate in [None, np.mean, np.max]:
                             yield (__test, S, sr, feature, n_fft,
-                                   hop_length, detrend, centering)
+                                   hop_length, detrend, center)
                             tf = raises(librosa.ParameterError)(__test)
                             yield (tf, None, sr, feature, n_fft,
-                                   hop_length, detrend, centering)
+                                   hop_length, detrend, center)
 
 
 def test_onset_strength_multi():

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -595,6 +595,7 @@ def test_warning_deprecated():
         return True
 
     warnings.resetwarnings()
+    warnings.simplefilter('always')
     with warnings.catch_warnings(record=True) as out:
         x = __dummy()
 
@@ -618,6 +619,7 @@ def test_warning_moved():
         return True
 
     warnings.resetwarnings()
+    warnings.simplefilter('always')
     with warnings.catch_warnings(record=True) as out:
         x = __dummy()
 


### PR DESCRIPTION
In this PR:

- [x] #249
- [x] #250 
- [x] Unit tests to validate centered onset strength shape
- [x] Tests to verify proper warnings on deprecated `centering=` parameter
- [x] minor efficiency tweak in `onset_strength_multi`
- [x] slight improvement to warning-detecting unit tests
- [x] update onset-dependent functions and examples to correspond to modifications