### PR TITLE
updates to CQT tests to fix #241

### DIFF
--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -121,17 +121,22 @@ def test_hybrid_cqt():
         eq_(C1.shape, C2.shape)
 
         # Check for numerical comparability
-        idx1 = (C1 > 1e-8)
-        idx2 = (C2 > 1e-8)
+        idx1 = (C1 > 1e-4 * C1.max())
+        idx2 = (C2 > 1e-4 * C2.max())
+
         perc = 0.99
-        thresh = 1e-4
-        assert np.percentile(np.abs(C1[idx1] - C2[idx1]), perc) < thresh
-        assert np.percentile(np.abs(C1[idx2] - C2[idx2]), perc) < thresh
+
+        thresh = 1e-3
+
+        idx = idx1 | idx2
+
+        assert np.percentile(np.abs(C1[idx] - C2[idx]),
+                             perc) < thresh * max(C1.max(), C2.max())
 
     for fmin in [None, librosa.note_to_hz('C2')]:
         for n_bins in [1, 12, 24, 48, 72, 74, 76]:
             for bins_per_octave in [12, 24]:
-                for tuning in [None, 0, 0.25]:
+                for tuning in [None, 0]:#, 0.25]:
                     for resolution in [1, 2]:
                         for norm in [1, 2]:
                             yield (__test, 512, fmin, n_bins,

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -136,7 +136,7 @@ def test_hybrid_cqt():
     for fmin in [None, librosa.note_to_hz('C2')]:
         for n_bins in [1, 12, 24, 48, 72, 74, 76]:
             for bins_per_octave in [12, 24]:
-                for tuning in [None, 0]:#, 0.25]:
+                for tuning in [None, 0, 0.25]:
                     for resolution in [1, 2]:
                         for norm in [1, 2]:
                             yield (__test, 512, fmin, n_bins,


### PR DESCRIPTION
As noted in the comment thread to #241, the issue here has to do with scipy's resampler behaving differently from libsamplerate, which makes the tests behave strangely in different environments.

This PR implements the following changes:

* test stimuli are exponential sine sweeps, rather than impulse trains.  It's a less brazenly synthetic input signal, and it still covers all the frequency bins without introducing ringing artifacts in downsampling.
* test criterion for hybrid cqt is now the following:
  - ~~for cq spectrograms C1 (full) and C2 (hybrid), the 99th percentile of bins which have sufficiently high energy (>1e-8) in either spectrogram must be below 1e-4.~~
  - EDIT: the above has been adapted to be more strict (in bins considered) and lax (in tolerance).  Selected bins must now exceed `1e-4 * C.max()`, and cannot deviate by more than `1e-3 * max(C1.max(), C2.max())`.
  - This test is more precise than the original (small mean deviation) since it disregards the (near-)zeros, and is robust to a small number of large outliers due to phase discrepancy or downsampling noise.