### PR TITLE
Adapt numpy 1.10.0  change of `numpy.pad`

### DIFF
--- a/librosa/feature/rhythm.py
+++ b/librosa/feature/rhythm.py
@@ -136,7 +136,7 @@ def tempogram(y=None, sr=22050, onset_envelope=None, hop_length=512,
     n = len(onset_envelope)
 
     if center:
-        onset_envelope = np.pad(onset_envelope, win_length // 2,
+        onset_envelope = np.pad(onset_envelope, int(win_length // 2),
                                 mode='linear_ramp', end_values=[0, 0])
 
     # Carve onset envelope into frames

--- a/librosa/feature/utils.py
+++ b/librosa/feature/utils.py
@@ -55,14 +55,14 @@ def delta(data, width=9, order=1, axis=-1, trim=True):
     >>> mfcc_delta
     array([[  2.929e+01,   3.090e+01, ...,   0.000e+00,   0.000e+00],
            [  2.226e+01,   2.553e+01, ...,   3.944e-31,   3.944e-31],
-           ..., 
+           ...,
            [ -1.192e+00,  -6.099e-01, ...,   9.861e-32,   9.861e-32],
            [ -5.349e-01,  -2.077e-01, ...,   1.183e-30,   1.183e-30]])
     >>> mfcc_delta2 = librosa.feature.delta(mfcc, order=2)
     >>> mfcc_delta2
     array([[  1.281e+01,   1.020e+01, ...,   0.000e+00,   0.000e+00],
            [  2.726e+00,   3.558e+00, ...,   0.000e+00,   0.000e+00],
-           ..., 
+           ...,
            [ -1.702e-01,  -1.509e-01, ...,   0.000e+00,   0.000e+00],
            [ -9.021e-02,  -7.007e-02, ...,  -2.190e-47,  -2.190e-47]])
 
@@ -99,6 +99,7 @@ def delta(data, width=9, order=1, axis=-1, trim=True):
 
     # Pad out the data by repeating the border values (delta=0)
     padding = [(0, 0)] * data.ndim
+    width = int(width)
     padding[axis] = (width, width)
     delta_x = np.pad(data, padding, mode='edge')
 
@@ -218,7 +219,7 @@ def stack_memory(data, n_steps=2, delay=1, **kwargs):
         kwargs.setdefault('constant_values', [0])
 
     # Pad the end with zeros, which will roll to the front below
-    data = np.pad(data, [(0, 0), ((n_steps - 1) * delay, 0)], **kwargs)
+    data = np.pad(data, [(0, 0), (int((n_steps - 1) * delay), 0)], **kwargs)
 
     history = data
 

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -83,7 +83,7 @@ def dct(n_filters, n_input):
     >>> dct_filters
     array([[ 0.031,  0.031, ...,  0.031,  0.031],
            [ 0.044,  0.044, ..., -0.044, -0.044],
-           ..., 
+           ...,
            [ 0.044,  0.044, ..., -0.044, -0.044],
            [ 0.044,  0.044, ...,  0.044,  0.044]])
 
@@ -143,7 +143,7 @@ def mel(sr, n_fft, n_mels=128, fmin=0.0, fmax=None, htk=False):
     >>> melfb
     array([[ 0.   ,  0.016, ...,  0.   ,  0.   ],
            [ 0.   ,  0.   , ...,  0.   ,  0.   ],
-           ..., 
+           ...,
            [ 0.   ,  0.   , ...,  0.   ,  0.   ],
            [ 0.   ,  0.   , ...,  0.   ,  0.   ]])
 
@@ -153,7 +153,7 @@ def mel(sr, n_fft, n_mels=128, fmin=0.0, fmax=None, htk=False):
     >>> librosa.filters.mel(22050, 2048, fmax=8000)
     array([[ 0.  ,  0.02, ...,  0.  ,  0.  ],
            [ 0.  ,  0.  , ...,  0.  ,  0.  ],
-           ..., 
+           ...,
            [ 0.  ,  0.  , ...,  0.  ,  0.  ],
            [ 0.  ,  0.  , ...,  0.  ,  0.  ]])
 
@@ -599,7 +599,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
     if pad_fft:
         max_len = int(2.0**(np.ceil(np.log2(max_len))))
     else:
-        max_len = np.ceil(max_len)
+        max_len = int(np.ceil(max_len))
 
     filters = np.asarray([util.pad_center(filt, max_len, **kwargs)
                           for filt in filters])

--- a/librosa/onset.py
+++ b/librosa/onset.py
@@ -301,7 +301,7 @@ def onset_strength(y=None, sr=22050, S=None, lag=1, max_size=1,
 
 
 @cache
-def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1, 
+def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
                          detrend=False, center=True, feature=None,
                          aggregate=None, channels=None, **kwargs):
     """Compute a spectral flux onset strength envelope across multiple channels.
@@ -454,7 +454,7 @@ def onset_strength_multi(y=None, sr=22050, S=None, lag=1, max_size=1,
         # Counter-act framing effects. Shift the onsets by n_fft / hop_length
         pad_width += n_fft // (2 * hop_length)
 
-    onset_env = np.pad(onset_env, ([0, 0], [pad_width, 0]), mode='constant')
+    onset_env = np.pad(onset_env, ([0, 0], [int(pad_width), 0]), mode='constant')
 
     # remove the DC component
     if detrend:

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -73,7 +73,7 @@ def frame(y, frame_length=2048, hop_length=512):
     >>> librosa.util.frame(y, frame_length=2048, hop_length=64)
     array([[ -9.216e-06,   7.710e-06, ...,  -2.117e-06,  -4.362e-07],
            [  2.518e-06,  -6.294e-06, ...,  -1.775e-05,  -6.365e-06],
-           ..., 
+           ...,
            [ -7.429e-04,   5.173e-03, ...,   1.105e-05,  -5.074e-06],
            [  2.169e-03,   4.867e-03, ...,   3.666e-06,  -5.571e-06]], dtype=float32)
 
@@ -281,7 +281,7 @@ def pad_center(data, size, axis=-1, **kwargs):
     lpad = int((size - n) // 2)
 
     lengths = [(0, 0)] * data.ndim
-    lengths[axis] = (lpad, size - n - lpad)
+    lengths[axis] = (lpad, int(size - n - lpad))
 
     if lpad < 0:
         raise ParameterError(('Target size ({:d}) must be '


### PR DESCRIPTION
`pad_length` must be of integral type (ref [NumPy 1.10.0 Release Notes#](https://github.com/numpy/numpy/blob/master/doc/release/1.10.0-notes.rst#nppad-supports-more-input-types-for-pad_width-and-constant_values)), otherwise it throws `TypeError`.

This PR should fix the test failure that I had with numpy 1.10.0:

```
$ nosetests -s -v tests/test_filters.py
... 
======================================================================
ERROR: test_filters.test_constant_q(11025, array([ 130.81278265]), 24, 24, 0.25, 2, False, 2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ryuichi/anaconda/envs/py35/lib/python3.5/site-packages/nose/case.py", line 198, in runTest
    self.test(*self.arg)
  File "/home/ryuichi/Dropbox/python/librosa/tests/test_filters.py", line 186, in __test
    norm=norm)
  File "/home/ryuichi/Dropbox/python/librosa/librosa/filters.py", line 605, in constant_q
    for filt in filters])
  File "/home/ryuichi/Dropbox/python/librosa/librosa/filters.py", line 605, in <listcomp>
    for filt in filters])
  File "/home/ryuichi/Dropbox/python/librosa/librosa/util/utils.py", line 291, in pad_center
    return np.pad(data, lengths, **kwargs)
  File "/home/ryuichi/anaconda/envs/py35/lib/python3.5/site-packages/numpy/lib/arraypad.py", line 1315, in pad
    raise TypeError('`pad_width` must be of integral type.')
TypeError: `pad_width` must be of integral type.
```
