### PR TITLE
Further CQT enhancements

### DIFF
--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -78,8 +78,8 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     Returns
     -------
-    CQT : np.ndarray [shape=(n_bins, t), dtype=np.float]
-        Constant-Q energy for each frequency at each time.
+    CQT : np.ndarray [shape=(n_bins, t), dtype=np.complex or np.float]
+        Constant-Q value each frequency at each time.
 
     Raises
     ------

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -382,16 +382,16 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
         fmin_full = np.min(freqs[~pseudo_filters])
 
-        my_cqt = cqt(y, sr,
-                     hop_length=hop_length,
-                     fmin=fmin_full,
-                     n_bins=n_bins_full,
-                     bins_per_octave=bins_per_octave,
-                     tuning=tuning,
-                     filter_scale=filter_scale,
-                     norm=norm,
-                     sparsity=sparsity,
-                     real=True)
+        my_cqt = np.abs(cqt(y, sr,
+                            hop_length=hop_length,
+                            fmin=fmin_full,
+                            n_bins=n_bins_full,
+                            bins_per_octave=bins_per_octave,
+                            tuning=tuning,
+                            filter_scale=filter_scale,
+                            norm=norm,
+                            sparsity=sparsity,
+                            real=False))
 
         cqt_resp.append(my_cqt)
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 import numpy as np
 import scipy.fftpack as fft
+from warnings import warn
 
 from . import audio
 from .time_frequency import cqt_frequencies, note_to_hz
@@ -16,9 +17,6 @@ from .. import util
 from ..util.exceptions import ParameterError
 
 __all__ = ['cqt', 'hybrid_cqt', 'pseudo_cqt']
-
-#TODO:   2015-11-09 16:48:08 by Brian McFee <brian.mcfee@nyu.edu>
-# deprecation warning for real=True 
 
 
 @cache
@@ -145,6 +143,13 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     filter_scale = util.rename_kw('resolution', resolution,
                                   'filter_scale', filter_scale,
                                   '0.4.2', '0.5.0')
+
+    if real:
+        warn('Real-valued CQT (real=True) is deprecated in 0.4.2. '
+             'Complex-valued CQT will become the default in 0.5.0. '
+             'Consider using np.abs(librosa.cqt(..., real=False)) '
+             'instead of real=True to maintain forward compatibility.',
+             DeprecationWarning)
 
     # How many octaves are we dealing with?
     n_octaves = int(np.ceil(float(n_bins) / bins_per_octave))

--- a/librosa/util/deprecation.py
+++ b/librosa/util/deprecation.py
@@ -9,7 +9,8 @@ import warnings
 
 class Deprecated(object):
     '''A dummy class to catch usage of deprecated variable names'''
-    pass
+    def __repr__(self):
+        return '<DEPRECATED parameter>'
 
 
 def rename_kw(old_name, old_value, new_name, new_value, version_deprecated, version_removed):

--- a/librosa/util/utils.py
+++ b/librosa/util/utils.py
@@ -1288,7 +1288,7 @@ def sync(data, idx, aggregate=None, pad=True, axis=-1):
     agg_shape = list(shape)
     agg_shape[axis] = len(slices)
 
-    data_agg = np.empty(agg_shape, order='F' if np.isfortran(data) else 'C')
+    data_agg = np.empty(agg_shape, order='F' if np.isfortran(data) else 'C', dtype=data.dtype)
 
     idx_in = [slice(None)] * data.ndim
     idx_agg = [slice(None)] * data_agg.ndim

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -25,17 +25,18 @@ from nose.tools import raises, eq_
 def __test_cqt_size(y, sr, hop_length, fmin, n_bins, bins_per_octave,
                     tuning, resolution, aggregate, norm, sparsity):
 
-    cqt_output = librosa.cqt(y,
-                             sr=sr,
-                             hop_length=hop_length,
-                             fmin=fmin,
-                             n_bins=n_bins,
-                             bins_per_octave=bins_per_octave,
-                             tuning=tuning,
-                             filter_scale=resolution,
-                             aggregate=aggregate,
-                             norm=norm,
-                             sparsity=sparsity)
+    cqt_output = np.abs(librosa.cqt(y,
+                                    sr=sr,
+                                    hop_length=hop_length,
+                                    fmin=fmin,
+                                    n_bins=n_bins,
+                                    bins_per_octave=bins_per_octave,
+                                    tuning=tuning,
+                                    filter_scale=resolution,
+                                    aggregate=aggregate,
+                                    norm=norm,
+                                    sparsity=sparsity,
+                                    real=False))
 
     eq_(cqt_output.shape[0], n_bins)
 
@@ -110,13 +111,13 @@ def test_hybrid_cqt():
                                 norm=norm,
                                 sparsity=sparsity)
 
-        C1 = librosa.cqt(y, sr=sr,
-                         hop_length=hop_length,
-                         fmin=fmin, n_bins=n_bins,
-                         bins_per_octave=bins_per_octave,
-                         tuning=tuning, filter_scale=resolution,
-                         norm=norm,
-                         sparsity=sparsity)
+        C1 = np.abs(librosa.cqt(y, sr=sr,
+                                hop_length=hop_length,
+                                fmin=fmin, n_bins=n_bins,
+                                bins_per_octave=bins_per_octave,
+                                tuning=tuning, filter_scale=resolution,
+                                norm=norm,
+                                sparsity=sparsity, real=False))
 
         eq_(C1.shape, C2.shape)
 
@@ -155,7 +156,7 @@ def test_cqt_position():
 
     def __test(note_min):
 
-        C = librosa.cqt(y, sr=sr, fmin=librosa.midi_to_hz(note_min))
+        C = np.abs(librosa.cqt(y, sr=sr, fmin=librosa.midi_to_hz(note_min), real=False))
 
         # Average over time
         Cbar = np.median(C, axis=1)

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -32,7 +32,7 @@ def __test_cqt_size(y, sr, hop_length, fmin, n_bins, bins_per_octave,
                              n_bins=n_bins,
                              bins_per_octave=bins_per_octave,
                              tuning=tuning,
-                             resolution=resolution,
+                             filter_scale=resolution,
                              aggregate=aggregate,
                              norm=norm,
                              sparsity=sparsity)
@@ -106,7 +106,7 @@ def test_hybrid_cqt():
                                 hop_length=hop_length,
                                 fmin=fmin, n_bins=n_bins,
                                 bins_per_octave=bins_per_octave,
-                                tuning=tuning, resolution=resolution,
+                                tuning=tuning, filter_scale=resolution,
                                 norm=norm,
                                 sparsity=sparsity)
 
@@ -114,7 +114,7 @@ def test_hybrid_cqt():
                          hop_length=hop_length,
                          fmin=fmin, n_bins=n_bins,
                          bins_per_octave=bins_per_octave,
-                         tuning=tuning, resolution=resolution,
+                         tuning=tuning, filter_scale=resolution,
                          norm=norm,
                          sparsity=sparsity)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -607,10 +607,6 @@ def test_estimate_tuning():
                                              fmin=librosa.note_to_hz('C4'),
                                              fmax=librosa.note_to_hz('G#9'))
 
-        print('target_hz={:.3f}'.format(target_hz))
-        print('tuning={:.3f}, estimated={:.3f}'.format(tuning, tuning_est))
-        print('resolution={:.2e}'.format(resolution))
-
         # Round to the proper number of decimals
         deviation = np.around(np.abs(tuning - tuning_est),
                               int(-np.log10(resolution)))

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -31,7 +31,7 @@ from nose.plugins.skip import SkipTest
 @nottest
 def get_spec(y, sr):
 
-    C = librosa.cqt(y, sr=sr)
+    C = np.abs(librosa.cqt(y, sr=sr, real=False))
     return librosa.stft(y), C, sr
 
 
@@ -295,19 +295,19 @@ def test_time_scales_explicit():
     plt.figure()
     plt.subplot(4, 1, 1)
     librosa.display.specshow(S_abs)
-    librosa.display.time_ticks(locs, times, fmt='ms')
+    librosa.display.time_ticks(locs, times, time_fmt='ms')
 
     plt.subplot(4, 1, 2)
     librosa.display.specshow(S_abs)
-    librosa.display.time_ticks(locs, times, fmt='s')
+    librosa.display.time_ticks(locs, times, time_fmt='s')
 
     plt.subplot(4, 1, 3)
     librosa.display.specshow(S_abs)
-    librosa.display.time_ticks(locs, times, fmt='m')
+    librosa.display.time_ticks(locs, times, time_fmt='m')
 
     plt.subplot(4, 1, 4)
     librosa.display.specshow(S_abs)
-    librosa.display.time_ticks(locs, times, fmt='h')
+    librosa.display.time_ticks(locs, times, time_fmt='h')
 
 
 @image_comparison(baseline_images=['waveplot_mono'], extensions=['png'])
@@ -391,9 +391,9 @@ def test_time_ticks_failure():
     def __test(locs, times, fmt, axis):
 
         if times is None:
-            librosa.display.time_ticks(locs, fmt=fmt, axis=axis)
+            librosa.display.time_ticks(locs, time_fmt=fmt, axis=axis)
         else:
-            librosa.display.time_ticks(locs, times, fmt=fmt, axis=axis)
+            librosa.display.time_ticks(locs, times, time_fmt=fmt, axis=axis)
 
     locs = np.linspace(0, 100.0)
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -173,7 +173,7 @@ def test__window():
 
 def test_constant_q():
 
-    def __test(sr, fmin, n_bins, bins_per_octave, tuning, resolution,
+    def __test(sr, fmin, n_bins, bins_per_octave, tuning, filter_scale,
                pad_fft, norm):
 
         F, lengths = librosa.filters.constant_q(sr,
@@ -181,7 +181,7 @@ def test_constant_q():
                                                 n_bins=n_bins,
                                                 bins_per_octave=bins_per_octave,
                                                 tuning=tuning,
-                                                resolution=resolution,
+                                                filter_scale=filter_scale,
                                                 pad_fft=pad_fft,
                                                 norm=norm)
 
@@ -214,7 +214,7 @@ def test_constant_q():
     # with negative bins
     yield (raises(librosa.ParameterError)(__test), sr, 60, -1, 12, 0, 1, True, 1)
 
-    # with negative resolution
+    # with negative filter_scale
     yield (raises(librosa.ParameterError)(__test), sr, 60, 1, 12, 0, -1, True, 1)
 
     # with negative norm
@@ -224,12 +224,12 @@ def test_constant_q():
         for n_bins in [12, 24]:
             for bins_per_octave in [12, 24]:
                 for tuning in [0, 0.25]:
-                    for resolution in [1, 2]:
+                    for filter_scale in [1, 2]:
                         for norm in [1, 2]:
                             for pad_fft in [False, True]:
                                 yield (__test, sr, fmin, n_bins,
                                        bins_per_octave, tuning,
-                                       resolution, pad_fft,
+                                       filter_scale, pad_fft,
                                        norm)
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -748,6 +748,9 @@ def test_sync():
         else:
             assert np.allclose(dsync, data)
 
+        # Test for dtype propagation
+        assert dsync.dtype == data.dtype
+
     @raises(librosa.ParameterError)
     def __test_fail(data, idx):
         librosa.util.sync(data, idx)


### PR DESCRIPTION
The current cqt implementation returns only magnitude.  If we're going to support inverse CQT #165 , phase will be critical for good reconstruction.

This PR is the first step in this direction.

It's currently implemented as API-compatible with the existing CQT; complex-output is enabled by setting `real=False`.  In 0.5, we should remove this parameter and make it always return complex-valued transforms.

As a side issue, this PR fixes `util.sync` to retain the `dtype` of the input data.