### PR TITLE
adding dummy .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*


### PR DESCRIPTION
Should fix missing coverage reports on coveralls.