### PR TITLE
CQT updates

### DIFF
--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -203,7 +203,7 @@ def to_mono(y):
 
 
 @cache
-def resample(y, orig_sr, target_sr, res_type='sinc_best', fix=True, **kwargs):
+def resample(y, orig_sr, target_sr, res_type='sinc_best', fix=True, scale=False, **kwargs):
     """Resample a time series from orig_sr to target_sr
 
     Parameters
@@ -231,6 +231,10 @@ def resample(y, orig_sr, target_sr, res_type='sinc_best', fix=True, **kwargs):
     fix : bool
         adjust the length of the resampled signal to be of size exactly
         `ceil(target_sr * len(y) / orig_sr)`
+
+    scale : bool
+        Scale the resampled signal so that `y` and `y_hat` have approximately
+        equal total energy.
 
     kwargs : additional keyword arguments
         If `fix==True`, additional keyword arguments to pass to
@@ -271,19 +275,22 @@ def resample(y, orig_sr, target_sr, res_type='sinc_best', fix=True, **kwargs):
     if orig_sr == target_sr:
         return y
 
-    n_samples = int(np.ceil(y.shape[-1] * float(target_sr) / orig_sr))
+    ratio = float(target_sr) / orig_sr
+
+    n_samples = int(np.ceil(y.shape[-1] * ratio))
 
     scipy_resample = (res_type == 'scipy')
 
     if _HAS_SAMPLERATE and not scipy_resample:
-        y_hat = samplerate.resample(y.T,
-                                    float(target_sr) / orig_sr,
-                                    res_type).T
+        y_hat = samplerate.resample(y.T, ratio, res_type).T
     else:
         y_hat = scipy.signal.resample(y, n_samples, axis=-1)
 
     if fix:
         y_hat = util.fix_length(y_hat, n_samples, **kwargs)
+
+    if scale:
+        y_hat /= ratio
 
     return np.ascontiguousarray(y_hat, dtype=y.dtype)
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -22,7 +22,7 @@ __all__ = ['cqt', 'hybrid_cqt', 'pseudo_cqt']
 @cache
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         bins_per_octave=12, tuning=None, filter_scale=1,
-        aggregate=None, norm=2, sparsity=0.01, real=False,
+        aggregate=None, norm=1, sparsity=0.01, real=False,
         resolution=util.Deprecated()):
     '''Compute the constant-Q transform of an audio signal.
 
@@ -248,7 +248,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
         # Resample (except first time)
         if i > 0:
-            my_y = audio.resample(my_y, my_sr, my_sr/2.0, res_type=res_type) * np.sqrt(2)
+            my_y = audio.resample(my_y, my_sr, my_sr/2.0, res_type=res_type, scale=True)
             my_sr /= 2.0
             assert my_hop % 2 == 0
             my_hop //= 2
@@ -593,7 +593,7 @@ def __early_downsample(y, sr, hop_length, res_type, n_octaves,
         assert hop_length % downsample_factor == 0
         hop_length //= downsample_factor
 
-        y = audio.resample(y, sr, sr / downsample_factor, res_type=res_type)
+        y = audio.resample(y, sr, sr / downsample_factor, res_type=res_type, scale=True)
 
         sr /= downsample_factor
 

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -21,7 +21,7 @@ __all__ = ['cqt', 'hybrid_cqt', 'pseudo_cqt']
 
 @cache
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
-        bins_per_octave=12, tuning=None, filter_scale=1,
+        bins_per_octave=12, tuning=None, filter_scale=None,
         aggregate=None, norm=1, sparsity=0.01, real=False,
         resolution=util.Deprecated()):
     '''Compute the constant-Q transform of an audio signal.
@@ -143,6 +143,10 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     filter_scale = util.rename_kw('resolution', resolution,
                                   'filter_scale', filter_scale,
                                   '0.4.2', '0.5.0')
+
+    # If filter_scale is None, auto-tune it based on frequency resolution
+    if filter_scale is None:
+        filter_scale = (2.0**(1./bins_per_octave) - 1.0)/(2.0**(1./12) - 1.0)
 
     if real:
         warn('Real-valued CQT (real=True) is deprecated in 0.4.2. '
@@ -268,7 +272,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
 @cache
 def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
-               bins_per_octave=12, tuning=None, filter_scale=2,
+               bins_per_octave=12, tuning=None, filter_scale=None,
                norm=1, sparsity=0.01,
                resolution=util.Deprecated()):
     '''Compute the hybrid constant-Q transform of an audio signal.
@@ -338,6 +342,10 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
                                   'filter_scale', filter_scale,
                                   '0.4.2', '0.5.0')
 
+    # If filter_scale is None, auto-tune it based on frequency resolution
+    if filter_scale is None:
+        filter_scale = (2.0**(1./bins_per_octave) - 1.0)/(2.0**(1./12) - 1.0)
+
     if fmin is None:
         # C1 by default
         fmin = note_to_hz('C1')
@@ -400,7 +408,7 @@ def hybrid_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
 @cache
 def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
-               bins_per_octave=12, tuning=None, filter_scale=2,
+               bins_per_octave=12, tuning=None, filter_scale=None,
                norm=1, sparsity=0.01,
                resolution=util.Deprecated()):
     '''Compute the pseudo constant-Q transform of an audio signal.
@@ -467,6 +475,10 @@ def pseudo_cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     filter_scale = util.rename_kw('resolution', resolution,
                                   'filter_scale', filter_scale,
                                   '0.4.2', '0.5.0')
+
+    # If filter_scale is None, auto-tune it based on frequency resolution
+    if filter_scale is None:
+        filter_scale = (2.0**(1./bins_per_octave) - 1.0)/(2.0**(1./12) - 1.0)
 
     if fmin is None:
         # C1 by default

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -21,8 +21,8 @@ __all__ = ['cqt', 'hybrid_cqt', 'pseudo_cqt']
 
 @cache
 def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
-        bins_per_octave=12, tuning=None, filter_scale=2,
-        aggregate=None, norm=1, sparsity=0.01, real=True,
+        bins_per_octave=12, tuning=None, filter_scale=1,
+        aggregate=None, norm=2, sparsity=0.01, real=False,
         resolution=util.Deprecated()):
     '''Compute the constant-Q transform of an audio signal.
 
@@ -248,7 +248,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
         # Resample (except first time)
         if i > 0:
-            my_y = audio.resample(my_y, my_sr, my_sr/2.0, res_type=res_type)
+            my_y = audio.resample(my_y, my_sr, my_sr/2.0, res_type=res_type) * np.sqrt(2)
             my_sr /= 2.0
             assert my_hop % 2 == 0
             my_hop //= 2

--- a/librosa/feature/spectral.py
+++ b/librosa/feature/spectral.py
@@ -913,12 +913,12 @@ def chroma_cqt(y=None, sr=22050, C=None, hop_length=512, fmin=None,
 
     # Build the CQT if we don't have one already
     if C is None:
-        C = cqt_func[cqt_mode](y, sr=sr,
-                           hop_length=hop_length,
-                           fmin=fmin,
-                           n_bins=n_octaves * bins_per_octave,
-                           bins_per_octave=bins_per_octave,
-                           tuning=tuning)
+        C = np.abs(cqt_func[cqt_mode](y, sr=sr,
+                                      hop_length=hop_length,
+                                      fmin=fmin,
+                                      n_bins=n_octaves * bins_per_octave,
+                                      bins_per_octave=bins_per_octave,
+                                      tuning=tuning))
 
     # Map to chroma
     cq_to_chr = filters.cq_to_chroma(C.shape[0],

--- a/librosa/filters.py
+++ b/librosa/filters.py
@@ -458,7 +458,7 @@ def __float_window(window_function):
 
 @cache
 def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
-               window=None, filter_scale=2, pad_fft=True, norm=1,
+               window=None, filter_scale=None, pad_fft=True, norm=1,
                resolution=util.Deprecated(), **kwargs):
     r'''Construct a constant-Q basis.
 
@@ -571,6 +571,10 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
                                   'filter_scale', filter_scale,
                                   '0.4.2', '0.5.0')
 
+    # If filter_scale is None, auto-tune it based on frequency resolution
+    if filter_scale is None:
+        filter_scale = (2.0**(1./bins_per_octave) - 1.0)/(2.0**(1./12) - 1.0)
+
     # Pass-through parameters to get the filter lengths
     lengths = constant_q_lengths(sr, fmin,
                                  n_bins=n_bins,
@@ -619,7 +623,7 @@ def constant_q(sr, fmin=None, n_bins=84, bins_per_octave=12, tuning=0.0,
 
 @cache
 def constant_q_lengths(sr, fmin, n_bins=84, bins_per_octave=12,
-                       tuning=0.0, window='hann', filter_scale=2,
+                       tuning=0.0, window='hann', filter_scale=None,
                        resolution=util.Deprecated()):
     r'''Return length of each filter in a constant-Q basis.
 
@@ -665,6 +669,10 @@ def constant_q_lengths(sr, fmin, n_bins=84, bins_per_octave=12,
     filter_scale = util.rename_kw('resolution', resolution,
                                   'filter_scale', filter_scale,
                                   '0.4.2', '0.5.0')
+
+    # If filter_scale is None, auto-tune it based on frequency resolution
+    if filter_scale is None:
+        filter_scale = (2.0**(1./bins_per_octave) - 1.0)/(2.0**(1./12) - 1.0)
 
     if fmin <= 0:
         raise ParameterError('fmin must be positive')

--- a/tests/test_constantq.py
+++ b/tests/test_constantq.py
@@ -170,10 +170,8 @@ def test_cqt_position():
         Cscale = Cbar / Cbar[idx]
         Cscale[idx] = np.nan
 
-        assert np.nanmax(Cscale) < 1e-1
-
         Cscale[idx-1:idx+2] = np.nan
-        assert np.nanmax(Cscale) < 1e-2
+        assert np.nanmax(Cscale) < 1e-1
 
     for note_min in [12, 18, 24, 30, 36]:
         yield __test, note_min

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -81,11 +81,11 @@ def test_segment_load():
 
 def test_resample_mono():
 
-    def __test(y, sr_in, sr_out, res_type, fix):
+    def __test(y, sr_in, sr_out, res_type, fix, scale):
 
         y2 = librosa.resample(y, sr_in, sr_out,
                               res_type=res_type,
-                              fix=fix)
+                              fix=fix, scale=scale)
 
         # First, check that the audio is valid
         librosa.util.valid_audio(y2, mono=True)
@@ -109,7 +109,8 @@ def test_resample_mono():
         for sr_out in [8000, 22050]:
             for res_type in ['sinc_fastest', 'sinc_best', 'scipy']:
                 for fix in [False, True]:
-                    yield (__test, y, sr_in, sr_out, res_type, fix)
+                    for scale in [False, True]:
+                        yield (__test, y, sr_in, sr_out, res_type, fix, scale)
 
 
 def test_resample_stereo():


### PR DESCRIPTION
Updates to CQT re: #165

- [x] added a `scale` parameter to `resample` so that output signals have the same energy after resampling
- [x] set `real=False` in `cqt` by default