### PR TITLE
[WIP] Resampy integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,6 @@ librosa (0.x.x, /path/to/librosa)
 
 ### Hints for OS X
 
-#### libsamplerate
-
-In order to use *scipy* with *libsamplerate*, you can use *homebrew* (http://brew.sh)
-for installation:
-```
-brew install libsamplerate
-```
-
-The Python bindings are installed via `pip install scikits.samplerate`.
-
 #### ffmpeg
 
 To fuel `audioread` with more audio-decoding power, you can install *ffmpeg* which

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -12,7 +12,6 @@ import scipy.signal
 import scipy.fftpack as fft
 import resampy
 
-
 from .time_frequency import frames_to_samples, time_to_samples
 from .. import cache
 from .. import util
@@ -275,6 +274,10 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
         y_hat = resampy.resample(y, orig_sr, target_sr, filter=res_type, axis=-1)
     except NotImplementedError:
         if _HAS_SAMPLERATE and (res_type != 'scipy'):
+            warnings.warn('scikits.samplerate resampling is deprecated as '
+                          'of librosa version 0.4.3.\n\tSupport will be '
+                          'removed in librosa version 0.5.',
+                          category=DeprecationWarning)
             y_hat = samplerate.resample(y.T, ratio, res_type).T
         else:
             y_hat = scipy.signal.resample(y, n_samples, axis=-1)

--- a/librosa/core/audio.py
+++ b/librosa/core/audio.py
@@ -24,7 +24,7 @@ __all__ = ['load', 'to_mono', 'resample', 'get_duration',
            'peak_pick', 'localmax']
 
 # Resampling bandwidths as percentage of Nyquist
-# http://www.mega-nerd.com/SRC/api_misc.html#Converters
+# http://resampy.readthedocs.org/en/latest/api.html#module-resampy.filters
 BW_BEST = 0.9476
 BW_FASTEST = 0.85
 
@@ -34,8 +34,6 @@ try:
     import scikits.samplerate as samplerate  # pylint: disable=import-error
     _HAS_SAMPLERATE = True
 except ImportError:
-    warnings.warn('Could not import scikits.samplerate. '
-                  'Falling back to scipy.signal')
     _HAS_SAMPLERATE = False
 
 
@@ -263,15 +261,8 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
 
     """
 
-    if y.ndim > 1:
-        return np.vstack([resample(yi, orig_sr, target_sr,
-                                   res_type=res_type,
-                                   fix=fix,
-                                   **kwargs)
-                          for yi in y])
-
     # First, validate the audio buffer
-    util.valid_audio(y, mono=True)
+    util.valid_audio(y, mono=False)
 
     if orig_sr == target_sr:
         return y
@@ -280,12 +271,10 @@ def resample(y, orig_sr, target_sr, res_type='kaiser_best', fix=True, scale=Fals
 
     n_samples = int(np.ceil(y.shape[-1] * ratio))
 
-    scipy_resample = (res_type == 'scipy')
-
     try:
         y_hat = resampy.resample(y, orig_sr, target_sr, filter=res_type, axis=-1)
     except NotImplementedError:
-        if _HAS_SAMPLERATE and not scipy_resample:
+        if _HAS_SAMPLERATE and (res_type != 'scipy'):
             y_hat = samplerate.resample(y.T, ratio, res_type).T
         else:
             y_hat = scipy.signal.resample(y, n_samples, axis=-1)

--- a/librosa/core/constantq.py
+++ b/librosa/core/constantq.py
@@ -176,13 +176,11 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
     nyquist = sr / 2.0
 
     if filter_cutoff < audio.BW_FASTEST * nyquist:
-        res_type = 'sinc_fastest'
-    elif filter_cutoff < audio.BW_MEDIUM * nyquist:
-        res_type = 'sinc_medium'
+        res_type = 'kaiser_fast'
     elif filter_cutoff < audio.BW_BEST * nyquist:
-        res_type = 'sinc_best'
+        res_type = 'kaiser_best'
     else:
-        res_type = 'sinc_best'
+        res_type = 'kaiser_best'
 
     cqt_resp = []
 
@@ -192,7 +190,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
 
     n_filters = min(bins_per_octave, n_bins)
 
-    if res_type != 'sinc_fastest' and audio._HAS_SAMPLERATE:
+    if res_type != 'kaiser_fast':
 
         # Do two octaves before resampling to allow for usage of sinc_fastest
         fft_basis, n_fft, filter_lengths = __fft_filters(sr, fmin_t,
@@ -221,7 +219,7 @@ def cqt(y, sr=22050, hop_length=512, fmin=None, n_bins=84,
         filter_cutoff = fmax_t * (1 + filters.window_bandwidth('hann') / Q)
         assert filter_cutoff < audio.BW_FASTEST*nyquist
 
-        res_type = 'sinc_fastest'
+        res_type = 'kaiser_fast'
 
     # Make sure our hop is long enough to support the bottom octave
     num_twos = __num_two_factors(hop_length)
@@ -581,7 +579,7 @@ def __early_downsample(y, sr, hop_length, res_type, n_octaves,
                        nyquist, filter_cutoff):
     '''Perform early downsampling on an audio signal, if it applies.'''
 
-    if not (res_type == 'sinc_fastest' and audio._HAS_SAMPLERATE):
+    if res_type != 'kaiser_fast':
         return y, sr, hop_length
 
     downsample_count1 = int(np.ceil(np.log2(audio.BW_FASTEST * nyquist /

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         'joblib >= 0.7.0',
         'decorator >= 3.0.0',
         'six >= 1.3',
+        'resampy >= 0.1.0'
     ],
     extras_require={
         'resample': 'scikits.samplerate>=0.3',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -107,7 +107,7 @@ def test_resample_mono():
         y, sr_in = librosa.load(infile, sr=None, duration=5)
 
         for sr_out in [8000, 22050]:
-            for res_type in ['sinc_fastest', 'sinc_best', 'scipy']:
+            for res_type in ['sinc_fastest', 'sinc_best', 'kaiser_best', 'kaiser_fast', 'scipy']:
                 for fix in [False, True]:
                     yield (__test, y, sr_in, sr_out, res_type, fix)
 
@@ -160,12 +160,12 @@ def test_resample_scale():
         n_res = np.sqrt(np.sum(np.abs(y2)**2))
 
         # If it's a no-op, make sure the signal is untouched
-        assert np.allclose(n_orig, n_res, atol=1e-2)
+        assert np.allclose(n_orig, n_res, atol=1e-2), (n_orig, n_res)
 
-    y, sr_in = librosa.load('data/test1_22050.wav', mono=True, sr=None, duration=5)
+    y, sr_in = librosa.load('data/test1_44100.wav', mono=True, sr=None, duration=5)
 
-    for sr_out in [8000, 11025, 22050, 44100]:
-        for res_type in ['sinc_fastest', 'scipy', 'sinc_best']:
+    for sr_out in [11025, 22050, 44100]:
+        for res_type in ['sinc_fastest', 'scipy', 'sinc_best', 'kaiser_best', 'kaiser_fast']:
             yield __test, sr_in, sr_out, res_type, y
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,6 +20,7 @@ import glob
 import numpy as np
 import scipy.io
 import six
+import warnings
 
 import matplotlib
 matplotlib.use('Agg')
@@ -167,6 +168,18 @@ def test_resample_scale():
     for sr_out in [11025, 22050, 44100]:
         for res_type in ['sinc_fastest', 'scipy', 'sinc_best', 'kaiser_best', 'kaiser_fast']:
             yield __test, sr_in, sr_out, res_type, y
+
+
+def test_resample_scikitsamplerate():
+    warnings.resetwarnings()
+    warnings.simplefilter('always')
+    with warnings.catch_warnings(record=True) as out:
+
+        librosa.resample(np.zeros(1000), 1000, 500, res_type='sinc_best')
+
+        assert len(out) > 0
+        assert out[0].category is DeprecationWarning
+        assert 'deprecated' in str(out[0].message).lower()
 
 
 @nottest


### PR DESCRIPTION
This PR implements #322.

- All resampling operations are switched over to use resampy by default
- CQT now uses resampy's `kaiser_best` and `kaiser_fast` for its downsampling
- audio.bandwidth parameters have been updated to match resampy's pre-computed roll-off frequencies
- the `resample` implementation has been simplified

Question for the other contributors (paging @ebattenberg @stefan-balke ):

Should we deprecate scikits.samplerate support?  I'm leaning toward yes, unless there's a strong argument in favor of keeping it going forward.  If we do deprecate it, I'll add the appropriate warning code in this PR.

TODO:

- [x] after resampy 0.1 release, remove force-install from travis and update setup.py requirements
- [x] deprecate scikits.samplerate?